### PR TITLE
Add user-managed custom rules feature

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
 # Build Stage
 
 FROM golang:1.13 AS build-env
-ADD . /src
-RUN cd /src && go build -o wakapi
+WORKDIR /src
+ADD ./go.mod .
+RUN go mod download
 
+ADD . .
+RUN go build -o wakapi
 
 # Final Stage
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       WAKAPI_DB_PASSWORD: "asdfasdfasdf"
       WAKAPI_DB_HOST: "db"
       WAKAPI_DB_PORT: "5432"
-      ENV: "dev"
+      ENVIRONMENT: "dev"
 
   db:
     image: postgres:12.3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3.7'
+
+services:
+  wakapi:
+    build: .
+    ports:
+      - 3000:3000
+    restart: always
+    environment:
+      WAKAPI_DB_TYPE: "postgres"
+      WAKAPI_DB_NAME: "wakapi"
+      WAKAPI_DB_USER: "wakapi"
+      WAKAPI_DB_PASSWORD: "asdfasdfasdf"
+      WAKAPI_DB_HOST: "db"
+      WAKAPI_DB_PORT: "5432"
+      ENV: "dev"
+
+  db:
+    image: postgres:12.3
+    ports:
+      - 5432:5432
+    environment:
+      POSTGRES_USER: "wakapi"
+      POSTGRES_PASSWORD: "asdfasdfasdf"
+      POSTGRES_DB: "wakapi"

--- a/migrations/sqlite3/6_customrule_table.sql
+++ b/migrations/sqlite3/6_customrule_table.sql
@@ -1,0 +1,15 @@
+-- +migrate Up
+-- SQL in section 'Up' is executed when this migration is applied
+
+create table custom_rules
+(
+    id               integer primary key autoincrement,
+    user_id          varchar(255) not null REFERENCES users (id) ON DELETE RESTRICT ON UPDATE RESTRICT,
+    extension        varchar(255),
+    language         varchar(255)
+);
+
+-- +migrate Down
+-- SQL section 'Down' is executed when this migration is rolled back
+
+DROP TABLE custom_rules;

--- a/models/customrule.go
+++ b/models/customrule.go
@@ -1,0 +1,18 @@
+package models
+
+
+type CustomRule struct {
+	ID             uint       `json:"id" gorm:"primary_key"`
+	User           *User      `json:"-" gorm:"not null"`
+	UserID         string     `json:"-" gorm:"not null; index:idx_customrule_user"`
+	Extension      string     `json:"extension"`
+	Language       string     `json:"language"`
+}
+
+func validateLanguage(language string) bool {
+	return len(language) >= 1
+}
+
+func validateExtension(extension string) bool {
+	return len(extension) >= 2
+}

--- a/models/customrule.go
+++ b/models/customrule.go
@@ -14,5 +14,5 @@ func validateLanguage(language string) bool {
 }
 
 func validateExtension(extension string) bool {
-	return len(extension) >= 2
+	return len(extension) >= 1
 }

--- a/models/heartbeat.go
+++ b/models/heartbeat.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"fmt"
 	"regexp"
 	"time"
 )
@@ -27,19 +28,13 @@ func (h *Heartbeat) Valid() bool {
 	return h.User != nil && h.UserID != "" && h.Time != CustomTime(time.Time{})
 }
 
-func (h *Heartbeat) Augment(customLangs map[string]string) {
-	if h.Language == "" {
-		if h.languageRegex == nil {
-			h.languageRegex = regexp.MustCompile(`^.+\.(.+)$`)
-		}
-		groups := h.languageRegex.FindAllStringSubmatch(h.Entity, -1)
-		if len(groups) == 0 || len(groups[0]) != 2 {
+func (h *Heartbeat) Augment(customRules []*CustomRule) {
+	for _, lang := range customRules {
+		reg := fmt.Sprintf(".*%s$", lang.Extension)
+		match, err := regexp.MatchString(reg, h.Entity)
+		if match && err == nil {
+			h.Language = lang.Language
 			return
 		}
-		ending := groups[0][1]
-		if _, ok := customLangs[ending]; !ok {
-			return
-		}
-		h.Language, _ = customLangs[ending]
 	}
 }

--- a/models/heartbeat.go
+++ b/models/heartbeat.go
@@ -28,7 +28,24 @@ func (h *Heartbeat) Valid() bool {
 	return h.User != nil && h.UserID != "" && h.Time != CustomTime(time.Time{})
 }
 
-func (h *Heartbeat) Augment(customRules []*CustomRule) {
+func (h *Heartbeat) AugmentWithConfigRules(customLangs map[string]string) {
+	if h.Language == "" {
+		if h.languageRegex == nil {
+			h.languageRegex = regexp.MustCompile(`^.+\.(.+)$`)
+		}
+		groups := h.languageRegex.FindAllStringSubmatch(h.Entity, -1)
+		if len(groups) == 0 || len(groups[0]) != 2 {
+			return
+		}
+		ending := groups[0][1]
+		if _, ok := customLangs[ending]; !ok {
+			return
+		}
+		h.Language, _ = customLangs[ending]
+	}
+}
+
+func (h *Heartbeat) AugmentWithUserRules(customRules []*CustomRule) {
 	for _, lang := range customRules {
 		reg := fmt.Sprintf(".*%s$", lang.Extension)
 		match, err := regexp.MatchString(reg, h.Entity)

--- a/routes/heartbeat.go
+++ b/routes/heartbeat.go
@@ -56,7 +56,8 @@ func (h *HeartbeatHandler) ApiPost(w http.ResponseWriter, r *http.Request) {
 		hb.Machine = machineName
 		hb.User = user
 		hb.UserID = user.ID
-		hb.Augment(rules)
+		hb.AugmentWithConfigRules(h.config.App.CustomLanguages)
+		hb.AugmentWithUserRules(rules)
 
 		if !hb.Valid() {
 			w.WriteHeader(http.StatusBadRequest)

--- a/routes/settings.go
+++ b/routes/settings.go
@@ -116,7 +116,7 @@ func (h *SettingsHandler) DeleteCustomRule(w http.ResponseWriter, r *http.Reques
 	user := r.Context().Value(models.UserKey).(*models.User)
 	ruleId, err := strconv.Atoi(r.PostFormValue("ruleid"))
 	if err != nil {
-		respondAlert(w, "internal server error", "", "settings.tpl.html", http.StatusInternalServerError)
+		respondAlert(w, "internal server error", "", conf.SettingsTemplate, http.StatusInternalServerError)
 		return
 	}
 
@@ -149,7 +149,7 @@ func (h *SettingsHandler) PostCreateCustomRule(w http.ResponseWriter, r *http.Re
 	};
 
 	if _, err := h.customRuleSrvc.Create(rule); err != nil {
-		respondAlert(w, "internal server error", "", "settings.tpl.html", http.StatusInternalServerError)
+		respondAlert(w, "internal server error", "", conf.SettingsTemplate, http.StatusInternalServerError)
 		return
 	}
 

--- a/routes/settings.go
+++ b/routes/settings.go
@@ -2,6 +2,7 @@ package routes
 
 import (
 	"fmt"
+	"strconv"
 	"github.com/gorilla/schema"
 	conf "github.com/muety/wakapi/config"
 	"github.com/muety/wakapi/models"
@@ -14,13 +15,15 @@ import (
 type SettingsHandler struct {
 	config   *conf.Config
 	userSrvc *services.UserService
+	customRuleSrvc *services.CustomRuleService
 }
 
 var credentialsDecoder = schema.NewDecoder()
 
-func NewSettingsHandler(userService *services.UserService) *SettingsHandler {
+func NewSettingsHandler(userService *services.UserService, customRuleService *services.CustomRuleService) *SettingsHandler {
 	return &SettingsHandler{
 		config:   conf.Get(),
+		customRuleSrvc: customRuleService,
 		userSrvc: userService,
 	}
 }
@@ -31,14 +34,14 @@ func (h *SettingsHandler) GetIndex(w http.ResponseWriter, r *http.Request) {
 	}
 
 	user := r.Context().Value(models.UserKey).(*models.User)
+	rules, _ := h.customRuleSrvc.GetCustomRuleForUser(user.ID)
 	data := map[string]interface{}{
 		"User": user,
+		"Rules": rules,
+		"Success": r.FormValue("success"),
+		"Error": r.FormValue("error"),
 	}
 
-	// TODO: when alerts are present, other data will not be passed to the template
-	if handleAlerts(w, r, conf.SettingsTemplate) {
-		return
-	}
 	templates[conf.SettingsTemplate].Execute(w, data)
 }
 
@@ -102,6 +105,56 @@ func (h *SettingsHandler) PostCredentials(w http.ResponseWriter, r *http.Request
 	http.SetCookie(w, cookie)
 
 	msg := url.QueryEscape("password was updated successfully")
+	http.Redirect(w, r, fmt.Sprintf("%s/settings?success=%s", h.config.Server.BasePath, msg), http.StatusFound)
+}
+
+func (h *SettingsHandler) DeleteCustomRule(w http.ResponseWriter, r *http.Request) {
+	if h.config.IsDev() {
+		loadTemplates()
+	}
+
+	user := r.Context().Value(models.UserKey).(*models.User)
+	ruleId, err := strconv.Atoi(r.PostFormValue("ruleid"))
+	if err != nil {
+		respondAlert(w, "internal server error", "", "settings.tpl.html", http.StatusInternalServerError)
+		return
+	}
+
+	rule := &models.CustomRule{
+		ID: uint(ruleId),
+		UserID: user.ID,
+	};
+	h.customRuleSrvc.Delete(rule)
+	msg := url.QueryEscape("Custom rule deleted successfully.");
+
+	http.Redirect(w, r, fmt.Sprintf("%s/settings?success=%s", h.config.Server.BasePath, msg), http.StatusFound)
+}
+
+func (h *SettingsHandler) PostCreateCustomRule(w http.ResponseWriter, r *http.Request) {
+	if h.config.IsDev() {
+		loadTemplates()
+	}
+	user := r.Context().Value(models.UserKey).(*models.User)
+	extension := r.PostFormValue("extension")
+	language := r.PostFormValue("language")
+
+	if extension[0] == '.' {
+		extension = extension[1:]
+	}
+
+	rule := &models.CustomRule{
+		UserID: user.ID,
+		Extension: extension,
+		Language: language,
+	};
+
+	if _, err := h.customRuleSrvc.Create(rule); err != nil {
+		respondAlert(w, "internal server error", "", "settings.tpl.html", http.StatusInternalServerError)
+		return
+	}
+
+	msg := url.QueryEscape("Custom rule saved successfully.");
+
 	http.Redirect(w, r, fmt.Sprintf("%s/settings?success=%s", h.config.Server.BasePath, msg), http.StatusFound)
 }
 

--- a/services/custom_rule.go
+++ b/services/custom_rule.go
@@ -1,0 +1,53 @@
+package services
+
+import (
+	"github.com/jinzhu/gorm"
+	"github.com/muety/wakapi/models"
+)
+
+type CustomRuleService struct {
+	Config *models.Config
+	Db     *gorm.DB
+}
+
+func NewCustomRuleService(db *gorm.DB) *CustomRuleService {
+	return &CustomRuleService{
+		Config: models.GetConfig(),
+		Db:     db,
+	}
+}
+
+func (srv *CustomRuleService) GetCustomRuleById(CustomRuleId uint) (*models.CustomRule, error) {
+	r := &models.CustomRule{}
+	if err := srv.Db.Where(&models.CustomRule{ID: CustomRuleId}).First(r).Error; err != nil {
+		return r, err
+	}
+	return r, nil
+}
+
+func (srv *CustomRuleService) GetCustomRuleForUser(userId string) ([]*models.CustomRule, error) {
+	var rules []*models.CustomRule
+	if err := srv.Db.
+		Where(&models.CustomRule{UserID: userId}).
+		Find(&rules).Error; err != nil {
+		return rules, err
+	}
+
+	return rules, nil
+}
+
+func (srv *CustomRuleService) Create(rule *models.CustomRule) (*models.CustomRule, error) {
+	result := srv.Db.Create(rule)
+	if err := result.Error; err != nil {
+		return nil, err
+	}
+
+	return rule, nil
+}
+
+func (srv *CustomRuleService) Delete(rule *models.CustomRule) {
+	srv.Db.
+		Where("id = ?", rule.ID).
+		Where("user_id = ?", rule.UserID).
+		Delete(models.CustomRule{})
+}

--- a/services/custom_rule.go
+++ b/services/custom_rule.go
@@ -2,24 +2,25 @@ package services
 
 import (
 	"github.com/jinzhu/gorm"
+	"github.com/muety/wakapi/config"
 	"github.com/muety/wakapi/models"
 )
 
 type CustomRuleService struct {
-	Config *models.Config
+	Config *config.Config
 	Db     *gorm.DB
 }
 
 func NewCustomRuleService(db *gorm.DB) *CustomRuleService {
 	return &CustomRuleService{
-		Config: models.GetConfig(),
+		Config: config.Get(),
 		Db:     db,
 	}
 }
 
-func (srv *CustomRuleService) GetCustomRuleById(CustomRuleId uint) (*models.CustomRule, error) {
+func (srv *CustomRuleService) GetCustomRuleById(customRuleId uint) (*models.CustomRule, error) {
 	r := &models.CustomRule{}
-	if err := srv.Db.Where(&models.CustomRule{ID: CustomRuleId}).First(r).Error; err != nil {
+	if err := srv.Db.Where(&models.CustomRule{ID: customRuleId}).First(r).Error; err != nil {
 		return r, err
 	}
 	return r, nil

--- a/services/summary.go
+++ b/services/summary.go
@@ -17,20 +17,22 @@ import (
 const HeartbeatDiffThreshold = 2 * time.Minute
 
 type SummaryService struct {
-	Config           *config.Config
-	Cache            *cache.Cache
-	Db               *gorm.DB
-	HeartbeatService *HeartbeatService
-	AliasService     *AliasService
+	Config                *config.Config
+	Cache                 *cache.Cache
+	Db                    *gorm.DB
+	HeartbeatService      *HeartbeatService
+	AliasService          *AliasService
+	CustomRuleService     *CustomRuleService
 }
 
-func NewSummaryService(db *gorm.DB, heartbeatService *HeartbeatService, aliasService *AliasService) *SummaryService {
+func NewSummaryService(db *gorm.DB, heartbeatService *HeartbeatService, aliasService *AliasService, customRuleService *CustomRuleService) *SummaryService {
 	return &SummaryService{
 		Config:           config.Get(),
 		Cache:            cache.New(24*time.Hour, 24*time.Hour),
 		Db:               db,
 		HeartbeatService: heartbeatService,
 		AliasService:     aliasService,
+		CustomRuleService: customRuleService,
 	}
 }
 

--- a/static/assets/app.js
+++ b/static/assets/app.js
@@ -304,3 +304,4 @@ window.addEventListener('load', function () {
     togglePlaceholders(getPresentDataMask())
     draw()
 })
+

--- a/static/assets/app.js
+++ b/static/assets/app.js
@@ -203,7 +203,7 @@ function togglePlaceholders(mask) {
 }
 
 function getPresentDataMask() {
-    return data.map(list => list.reduce((acc, e) => acc + e.total, 0) > 0)
+    return data.map(list => list ? list.reduce((acc, e) => acc + e.total, 0) : 0 > 0)
 }
 
 function getContainer(chart) {

--- a/views/settings.tpl.html
+++ b/views/settings.tpl.html
@@ -32,7 +32,8 @@
                     <label class="inline-block text-sm mb-1 text-gray-500" for="password_new">New Password</label>
                     <input class="shadow appearance-none bg-gray-800 focus:bg-gray-700 text-gray-300 border-green-700 focus:border-gray-500 border rounded w-full py-1 px-3"
                            type="password" id="password_new"
-                           name="password_new" placeholder="Choose a password" minlength="6" required> </div>
+                           name="password_new" placeholder="Choose a password" minlength="6" required>
+                </div>
                 <div class="mb-8">
                     <label class="inline-block text-sm mb-1 text-gray-500" for="password_repeat">And again ...</label>
                     <input class="shadow appearance-none bg-gray-800 focus:bg-gray-700 text-gray-300 border-green-700 focus:border-gray-500 border rounded w-full py-1 px-3"
@@ -154,8 +155,7 @@
                             </div>
                         </div>
 
-                        <
-                        zzp>You can also add <span class="text-xs bg-gray-900 rounded py-1 px-2 font-mono">/project:your-cool-project</span> to the URL to filter by project.</p>
+                        <p>You can also add <span class="text-xs bg-gray-900 rounded py-1 px-2 font-mono">/project:your-cool-project</span> to the URL to filter by project.</p>
                     {{ else }}
                         <p>You have the ability to create badges from your coding statistics using <a href="https://shields.io" target="_blank" class="border-b border-green-800" rel="noopener noreferrer">Shields.io</a>. To do so, you need to grant public, unauthorized access to the respective endpoint.</p>
                         <div class="flex justify-around mt-4">
@@ -189,3 +189,4 @@
 </body>
 
 </html>
+

--- a/views/settings.tpl.html
+++ b/views/settings.tpl.html
@@ -70,42 +70,43 @@
             <div class="font-semibold text-lg text-white m-0 border-b-2 border-green-700 inline-block">
                 Custom Rules
             </div>
+            
+            <div class="text-gray-300 text-sm mb-4 mt-6">
+                Custom rules modify future coding activity, they’re useful for correcting languages displayed wrong on your dashboard.
+            </div>
 
             {{ if .Rules }}
-
             {{ range $i, $rule := .Rules }}
-                <div class="text-white border-1 w-full border-green-700 inline-block my-1 py-1 text-align">
-                    <label class="inline-block text-sm mb-1 text-gray-500" >When filename ends in:</label>
-                    {{ $rule.Extension }}
-                    <label class="inline-block text-sm mb-1 text-gray-500" >Change the language to:</label>
-                    {{ $rule.Language }}
+            <div class="text-white border-1 w-full border-green-700 inline-block my-1 py-1 text-align">
+                <label class="inline-block text-sm mb-1 text-gray-500" >When filename ends in:</label>
+                {{ $rule.Extension }}
+                <label class="inline-block text-sm mb-1 text-gray-500" >Change the language to:</label>
+                {{ $rule.Language }}
 
-                    <form class="float-right" action="settings/customrules/delete" method="post">
-                        <input type="hidden" id="ruleid" name="ruleid" required value="{{ $rule.ID }}">
-                        <button type="submit" class="py-1 px-3 rounded bg-red-500 hover:bg-red-600 text-white text-sm">
-                            Remove
-                        </button>
-                    </form>
-                </div>
-                {{end}}
-            {{else}}
-                <div class="text-white border-1 w-full border-green-700 inline-block my-1 py-1">
-                    No rules.
-                </div>
+                <form class="float-right" action="settings/customrules/delete" method="post">
+                    <input type="hidden" id="ruleid" name="ruleid" required value="{{ $rule.ID }}">
+                    <button type="submit" class="py-1 px-3 rounded bg-red-500 hover:bg-red-600 text-white text-sm">
+                        Remove
+                    </button>
+                </form>
+            </div>
             {{end}}
-            
+            {{else}}
+            <div class="text-white border-1 w-full border-green-700 inline-block my-1 py-1">
+                No rules.
+            </div>
+            {{end}}
 
-            <form class="mt-10" action="settings/customrules" method="post">
-                <div class="flex justify-around mt-4">
-
+            <form action="settings/customrules" method="post">
+                <div class="inline-block justify-around mt-4 w-full">
                     <label class="inline-block text-sm mb-1 text-gray-500" for="extension">When filename ends in:</label>
-                    <input class="shadow appearance-none bg-gray-800 focus:bg-gray-700 text-gray-300 border-green-700 focus:border-gray-500 border rounded w-full py-1 px-3"
+                    <input class="shadow appearance-nonshadow appearance-none bg-gray-800 focus:bg-gray-700 text-gray-300 border-green-700 focus:border-gray-500 border rounded w-full py-1 px-3"
                            type="text" id="extension"
                            name="extension" placeholder="py" minlength="1" required>
                 </div>
-                <div class="flex justify-around mt-4">
+                <div class="inline-block justify-around mt-4 w-full">
                     <label class="inline-block text-sm mb-1 text-gray-500" for="language">Change the language to:</label>
-                    <input class="shadow appearance-none bg-gray-800 focus:bg-gray-700 text-gray-300 border-green-700 focus:border-gray-500 border rounded w-full py-1 px-3"
+                    <input class="shadow appearance-nonshadow appearance-none bg-gray-800 focus:bg-gray-700 text-gray-300 border-green-700 focus:border-gray-500 border rounded w-full py-1 px-3"
                            type="text" id="language"
                            name="language" placeholder="Python" minlength="1" required>
                 </div>

--- a/views/settings.tpl.html
+++ b/views/settings.tpl.html
@@ -32,8 +32,7 @@
                     <label class="inline-block text-sm mb-1 text-gray-500" for="password_new">New Password</label>
                     <input class="shadow appearance-none bg-gray-800 focus:bg-gray-700 text-gray-300 border-green-700 focus:border-gray-500 border rounded w-full py-1 px-3"
                            type="password" id="password_new"
-                           name="password_new" placeholder="Choose a password" minlength="6" required>
-                </div>
+                           name="password_new" placeholder="Choose a password" minlength="6" required> </div>
                 <div class="mb-8">
                     <label class="inline-block text-sm mb-1 text-gray-500" for="password_repeat">And again ...</label>
                     <input class="shadow appearance-none bg-gray-800 focus:bg-gray-700 text-gray-300 border-green-700 focus:border-gray-500 border rounded w-full py-1 px-3"
@@ -64,6 +63,58 @@
                     </button>
                 </div>
             </form>
+        </div>
+
+        <div class="w-full mt-4 mb-8 pb-8">
+            <div class="font-semibold text-lg text-white m-0 border-b-2 border-green-700 inline-block">
+                Custom Rules
+            </div>
+
+            {{ if .Rules }}
+
+            {{ range $i, $rule := .Rules }}
+                <div class="text-white border-1 w-full border-green-700 inline-block my-1 py-1 text-align">
+                    <label class="inline-block text-sm mb-1 text-gray-500" >When filename ends in:</label>
+                    {{ $rule.Extension }}
+                    <label class="inline-block text-sm mb-1 text-gray-500" >Change the language to:</label>
+                    {{ $rule.Language }}
+
+                    <form class="float-right" action="settings/customrules/delete" method="post">
+                        <input type="hidden" id="ruleid" name="ruleid" required value="{{ $rule.ID }}">
+                        <button type="submit" class="py-1 px-3 rounded bg-red-500 hover:bg-red-600 text-white text-sm">
+                            Remove
+                        </button>
+                    </form>
+                </div>
+                {{end}}
+            {{else}}
+                <div class="text-white border-1 w-full border-green-700 inline-block my-1 py-1">
+                    No rules.
+                </div>
+            {{end}}
+            
+
+            <form class="mt-10" action="settings/customrules" method="post">
+                <div class="flex justify-around mt-4">
+
+                    <label class="inline-block text-sm mb-1 text-gray-500" for="extension">When filename ends in:</label>
+                    <input class="shadow appearance-none bg-gray-800 focus:bg-gray-700 text-gray-300 border-green-700 focus:border-gray-500 border rounded w-full py-1 px-3"
+                           type="text" id="extension"
+                           name="extension" placeholder="py" minlength="1" required>
+                </div>
+                <div class="flex justify-around mt-4">
+                    <label class="inline-block text-sm mb-1 text-gray-500" for="language">Change the language to:</label>
+                    <input class="shadow appearance-none bg-gray-800 focus:bg-gray-700 text-gray-300 border-green-700 focus:border-gray-500 border rounded w-full py-1 px-3"
+                           type="text" id="language"
+                           name="language" placeholder="Python" minlength="1" required>
+                </div>
+                <div class="flex justify-between float-right">
+                    <button type="submit" class="py-1 px-3 my-3 rounded bg-green-700 hover:bg-green-800 text-white text-sm">
+                        Add rule
+                    </button>
+                </div>
+            </form>
+
         </div>
 
         <div class="w-full mt-4 mb-8 pb-8">
@@ -103,7 +154,8 @@
                             </div>
                         </div>
 
-                        <p>You can also add <span class="text-xs bg-gray-900 rounded py-1 px-2 font-mono">/project:your-cool-project</span> to the URL to filter by project.</p>
+                        <
+                        zzp>You can also add <span class="text-xs bg-gray-900 rounded py-1 px-2 font-mono">/project:your-cool-project</span> to the URL to filter by project.</p>
                     {{ else }}
                         <p>You have the ability to create badges from your coding statistics using <a href="https://shields.io" target="_blank" class="border-b border-green-800" rel="noopener noreferrer">Shields.io</a>. To do so, you need to grant public, unauthorized access to the respective endpoint.</p>
                         <div class="flex justify-around mt-4">

--- a/wait-for-it.sh
+++ b/wait-for-it.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 if [ "$WAKAPI_DB_TYPE" != "sqlite3" ]; then
-  echo "Waiting 3 Seconds for DB to start"
-  sleep 3;
+  echo "Waiting 10 Seconds for DB to start"
+  sleep 10;
 fi
 
 echo "Starting Application"

--- a/wait-for-it.sh
+++ b/wait-for-it.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 if [ "$WAKAPI_DB_TYPE" != "sqlite3" ]; then
-  echo "Waiting 10 Seconds for DB to start"
-  sleep 10;
+  echo "Waiting 3 Seconds for DB to start"
+  sleep 3;
 fi
 
 echo "Starting Application"


### PR DESCRIPTION
Hey there. I've been using this project for a while now and thought it would be great to let users input their own custom rules to changes the heartbeat's language based on the filename. While searching the code, I found something very similar [here](https://github.com/muety/wakapi/blob/177cbb12fcc46f9f63b4f65b482847eaad6e5f98/config.default.yml#L11) and thought it would be great to have a way to edit those rules on a per-user basis.

To do this, I added a custom_rule model and services and added endpoints to let the user create/delete them. Then, when an heartbeat is received, the rule is applied in the `Augment` function.

## Heres some screenshot: 

I was inspired by this (From wakatime):

![image](https://user-images.githubusercontent.com/25652765/97100530-a8d7ee00-166a-11eb-83e8-4713f4d93d7b.png)

### In Wakapi :

![image](https://user-images.githubusercontent.com/25652765/97100543-c6a55300-166a-11eb-8026-7d11825407b9.png)

![image](https://user-images.githubusercontent.com/25652765/97100554-dae95000-166a-11eb-85e0-b7b82ab6eba8.png)

![image](https://user-images.githubusercontent.com/25652765/97100660-1afd0280-166c-11eb-9abb-4a05d10e6c41.png)


Let me know what you think. BTW, are there any linter / code format tools I should be using for go? Should I use any of them before opening a PR? 