### PR TITLE
Added missing closing parens in language mapping description

### DIFF
--- a/views/settings.tpl.html
+++ b/views/settings.tpl.html
@@ -75,7 +75,7 @@
             </div>
             
             <div class="text-gray-300 text-sm mb-4 mt-6">
-                You can specify custom mapping from file extensions to programming languages (e.g. a <span class="text-xs bg-gray-900 rounded py-1 px-2 font-mono">.jsx</span> file could be mapped to <span class="text-xs bg-gray-900 rounded py-1 px-2 font-mono">React</span>.
+                You can specify custom mapping from file extensions to programming languages (e.g. a <span class="text-xs bg-gray-900 rounded py-1 px-2 font-mono">.jsx</span> file could be mapped to <span class="text-xs bg-gray-900 rounded py-1 px-2 font-mono">React</span>.)
             </div>
 
             {{ if .LanguageMappings }}


### PR DESCRIPTION
Fix a very minor typo where the closing parens was missing.
## Before
![image](https://user-images.githubusercontent.com/25652765/100690872-74381000-3355-11eb-9b68-a1f935e4bd5d.png)

## After
![image](https://user-images.githubusercontent.com/25652765/100690697-173c5a00-3355-11eb-8247-ea638f5eb49e.png)