### PR TITLE
ci(docker): Publish Docker Image on Release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,42 @@
+name: Publish Docker Image
+
+on:
+  push:
+    tags:
+      - '*.*.*'
+      - '!*.*.*-*'
+
+jobs:
+  docker-publish:
+    runs-on: ubuntu-latest
+    steps:
+      # https://stackoverflow.com/questions/58177786
+      - name: Get version
+        run: echo "GIT_TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push to Docker Hub
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: |
+            n1try/wakapi:${{ env.GIT_TAG }}
+            n1try/wakapi:latest
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/linux-build-on-release.yml
+++ b/.github/workflows/linux-build-on-release.yml
@@ -2,10 +2,11 @@ name: Build Wakapi on Linux
 
 on:
   push:
+    branches:
   pull_request:
   release:
     types:
-      - created
+      - published
 
 jobs:
   build-and-release:

--- a/.github/workflows/win-build-on-release.yml
+++ b/.github/workflows/win-build-on-release.yml
@@ -2,10 +2,11 @@ name: Build Wakapi on Windows
 
 on:
   push:
+    branches:
   pull_request:
   release:
     types:
-      - created
+      - published
 
 jobs:
   build-and-release:


### PR DESCRIPTION
Resolves #110 

Reference:
https://github.com/marketplace/actions/build-and-push-docker-images#leverage-github-cache
https://github.com/marketplace/actions/build-and-push-docker-images#customizing

```
on:
    push:

jobs:
    a:
        runs-on: ubuntu-latest
        steps:
          - run: echo "A=/etc/passwd" >> $GITHUB_ENV
          - run: |
              cat ${{ env.A }}
              echo "hi"

```
runs successfully. 

Sample run:
https://github.com/YC/wakapi/runs/1821990900?check_suite_focus=true
https://github.com/YC/wakapi/actions/runs/533688180/workflow

Note: the correctness of L38-40 is uncertain