### PR TITLE
Fixed scale label to show seconds instead of minutes

### DIFF
--- a/static/assets/app.js
+++ b/static/assets/app.js
@@ -112,7 +112,7 @@ function draw(subselection) {
                     xAxes: [{
                         scaleLabel: {
                             display: true,
-                            labelString: 'Minutes'
+                            labelString: 'Seconds'
                         }
                     }]
                 },


### PR DESCRIPTION
Small one. I thought something was off with the scale... 

I'm not sure if this is the right fix for this, maybe we should use minutes instead of seconds? LMK if I should change it to show the time in minutes instead.

<img width="483" alt="image" src="https://user-images.githubusercontent.com/25652765/108620930-71e9cd00-73fd-11eb-930e-3d18ebc3a1e4.png">

Probably closes #135 