### PR TITLE
allow custom mappings with dot (issue #144)

### DIFF
--- a/models/heartbeat.go
+++ b/models/heartbeat.go
@@ -4,15 +4,9 @@ import (
 	"fmt"
 	"github.com/emvi/logbuch"
 	"github.com/mitchellh/hashstructure/v2"
-	"regexp"
+	"strings"
 	"time"
 )
-
-var languageRegex *regexp.Regexp
-
-func init() {
-	languageRegex = regexp.MustCompile(`^.+\.(.+)$`)
-}
 
 type Heartbeat struct {
 	ID              uint       `gorm:"primary_key" hash:"ignore"`
@@ -40,15 +34,12 @@ func (h *Heartbeat) Valid() bool {
 }
 
 func (h *Heartbeat) Augment(languageMappings map[string]string) {
-	groups := languageRegex.FindAllStringSubmatch(h.Entity, -1)
-	if len(groups) == 0 || len(groups[0]) != 2 {
-		return
+	for ending, value := range languageMappings {
+		if strings.HasSuffix(h.Entity, "."+ending) {
+			h.Language = value
+			return
+		}
 	}
-	ending := groups[0][1]
-	if _, ok := languageMappings[ending]; !ok {
-		return
-	}
-	h.Language, _ = languageMappings[ending]
 }
 
 func (h *Heartbeat) GetKey(t uint8) (key string) {


### PR DESCRIPTION
I had troubles to get my `.blade.php` files recognised as `Blade` files. Therefore I changed the mapping algorithm to check for a suffix instead of using a regex to get the extension (after the last dot in the filename) and compare this extension to the custom mappings.

I think this is a more convenient way for any use cases and won't break anything.