### PR TITLE
Fix compatible with new wakatime-cli

### DIFF
--- a/utils/common.go
+++ b/utils/common.go
@@ -46,7 +46,7 @@ func Add(i, j int) int {
 }
 
 func ParseUserAgent(ua string) (string, string, error) {
-	re := regexp.MustCompile(`(?iU)^wakatime\/[\d+.]+\s\((\w+)-.*\)\s.+\s([^\/\s]+)-wakatime\/.+$`)
+	re := regexp.MustCompile(`(?iU)^wakatime\/v?[\d+.]+\s\((\w+)-.*\)\s.+\s([^\/\s]+)-wakatime\/.+$`)
 	groups := re.FindAllStringSubmatch(ua, -1)
 	if len(groups) == 0 || len(groups[0]) != 3 {
 		return "", "", errors.New("failed to parse user agent string")

--- a/utils/common_test.go
+++ b/utils/common_test.go
@@ -37,6 +37,12 @@ func TestCommon_ParseUserAgent(t *testing.T) {
 			"",
 			errors.New(""),
 		},
+		{
+			"wakatime/v1.18.11 (linux-5.13.8-200.fc34.x86_64-x86_64) go1.16.7 emacs-wakatime/1.0.2",
+			"linux",
+			"emacs",
+			nil,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Hi, the version number of new [wakatime-cli](https://github.com/wakatime/wakatime-cli) (golang version) starts with `v`, like [v1.18.11](https://github.com/wakatime/wakatime-cli/releases/tag/v1.18.11).

So this regular expression needs to be updated to support it.