### PR TITLE
Normalize information received in hearbeats

### DIFF
--- a/models/heartbeat.go
+++ b/models/heartbeat.go
@@ -34,6 +34,12 @@ func (h *Heartbeat) Valid() bool {
 	return h.User != nil && h.UserID != "" && h.User.ID == h.UserID && h.Time != CustomTime(time.Time{})
 }
 
+func (h *Heartbeat) Normalize() {
+	h.Language = strings.Title(strings.ToLower(h.Language))
+	h.OperatingSystem = strings.Title(strings.ToLower(h.OperatingSystem))
+	h.Editor = strings.Title(strings.ToLower(h.Editor))
+}
+
 func (h *Heartbeat) Augment(languageMappings map[string]string) {
 	maxPrec := -1 // precision / mapping complexity -> more concrete ones shall take precedence
 	for ending, value := range languageMappings {

--- a/services/heartbeat.go
+++ b/services/heartbeat.go
@@ -179,6 +179,7 @@ func (srv *HeartbeatService) augmented(heartbeats []*models.Heartbeat, userId st
 
 	for i := range heartbeats {
 		heartbeats[i].Augment(languageMapping)
+		heartbeats[i].Normalize()
 	}
 
 	return heartbeats, nil


### PR DESCRIPTION
This pull requests add a `Normalize` function which transform some information in the heartbeat into a lowercase but titled string. Heartbeats are normalized after rules were applied in order to not create any conflict with them. 

This is an attempt to make Wakapi case insensitive, and should closes #234

I've had the same issue in the past (Ignore the `unknown` entries:)

<img width="437" alt="image" src="https://user-images.githubusercontent.com/25652765/131415336-4fb39ff1-af22-4111-bd94-884f28cdac06.png">

 Now after using the Normalize functions, data looks like this:

<img width="924" alt="image" src="https://user-images.githubusercontent.com/25652765/131415053-bf24706c-3f49-4d75-b75c-34de93a6cb01.png">

I think this is a pretty simple solution, but I am concerned as to how this would behave with older information that were already saved from past heartbeats...

Do you have any suggestion on how we could address this?  