### PR TITLE
fix(docs): wrong parameter in OpenAPI-Docs

### DIFF
--- a/routes/compat/wakatime/v1/stats.go
+++ b/routes/compat/wakatime/v1/stats.go
@@ -47,7 +47,7 @@ func (h *StatsHandler) RegisterRoutes(router *mux.Router) {
 // @Tags wakatime
 // @Produce json
 // @Param user path string true "User ID to fetch data for (or 'current')"
-// @Param range query string false "Range interval identifier" Enums(today, yesterday, week, month, year, 7_days, last_7_days, 30_days, last_30_days, 12_months, last_12_months, any)
+// @Param range path string false "Range interval identifier" Enums(today, yesterday, week, month, year, 7_days, last_7_days, 30_days, last_30_days, 12_months, last_12_months, any)
 // @Security ApiKeyAuth
 // @Success 200 {object} v1.StatsViewModel
 // @Router /compat/wakatime/v1/users/{user}/stats/{range} [get]

--- a/static/docs/docs.go
+++ b/static/docs/docs.go
@@ -313,7 +313,7 @@ var doc = `{
                         "type": "string",
                         "description": "Range interval identifier",
                         "name": "range",
-                        "in": "query"
+                        "in": "path"
                     }
                 ],
                 "responses": {

--- a/static/docs/swagger.json
+++ b/static/docs/swagger.json
@@ -297,7 +297,7 @@
                         "type": "string",
                         "description": "Range interval identifier",
                         "name": "range",
-                        "in": "query"
+                        "in": "path"
                     }
                 ],
                 "responses": {

--- a/static/docs/swagger.yaml
+++ b/static/docs/swagger.yaml
@@ -524,7 +524,7 @@ paths:
         - 12_months
         - last_12_months
         - any
-        in: query
+        in: path
         name: range
         type: string
       produces:


### PR DESCRIPTION
Hi there!

The parameter `range` of `/compat/wakatime/v1/users/{user}/stats/{range} [get]` is path.
However, it was described as query in OpenAPI-Docs.
So, I fixed it and generated files in `static/docs`.

Closes: #239