### PR TITLE
fix: relative swagger-ui definition

### DIFF
--- a/static/swagger-ui/index.html
+++ b/static/swagger-ui/index.html
@@ -41,7 +41,7 @@
     window.onload = function() {
       // Begin Swagger UI call region
       const ui = SwaggerUIBundle({
-        url: "/docs/swagger.json",
+        url: "../docs/swagger.json",
         dom_id: '#swagger-ui',
         deepLinking: true,
         presets: [


### PR DESCRIPTION
Relevant for those hosting wakapi on subdirectory
Note: /swagger-ui redirects to /swagger-ui/