### PR TITLE
fix: href to a 404 when service on a subpath

### DIFF
--- a/static/assets/js/summary.js
+++ b/static/assets/js/summary.js
@@ -132,9 +132,9 @@ function draw(subselection) {
                 onClick: (event, data) => {
                     const idx = data[0].index
                     const name = wakapiData.projects[idx].key
-                    const query = new URLSearchParams(window.location.search)
-                    query.set('project', name)
-                    window.location.replace(`${window.location.pathname.slice(1)}?${query.toString()}`)
+                    const url = new URL(window.location.href)
+                    url.searchParams.set('query', name)
+                    window.location.href = a.href
                 },
                 onHover: (event, elem) => {
                     event.native.target.style.cursor = elem[0] ? 'pointer' : 'default'


### PR DESCRIPTION
click project detail will redirect to a not exist page, when the service runs with a base path.

For example, the base path is `wakatime`,  and the dashboard uri will be `/wakatime/summary`. When click project detail, page will be redirect to `/wakatime/wakatime/summary?project=demo` but the correct detail page is `/wakatime/summary?project=demo`.

And i think `pushing a history stack` is better than `replace`, so that can back to dashboard by backwards.