### PR TITLE
add error when no authentication is configured

### DIFF
--- a/services/mail/smtp.go
+++ b/services/mail/smtp.go
@@ -49,6 +49,11 @@ func (s *SMTPSendingService) Send(mail *models.Mail) error {
 		if ok, _ := c.Extension("AUTH"); !ok {
 			return errors.New("smtp: server doesn't support AUTH")
 		}
+
+		if len(s.config.Username) == 0 || len(s.config.Password) == 0 {
+			return errors.New("smtp: server requires authentification, but no authentification is provided")
+		}
+
 		if err = c.Auth(s.auth); err != nil {
 			return err
 		}


### PR DESCRIPTION
I wasted like half hour because I used `WAKAPI_MAIL_SMTP_USERNAME` instead of `WAKAPI_MAIL_SMTP_USER`

Btw: Can we please add all env to the README. The sentence to look into the config doesn't help. It is in the config **username** and not **user**