### PR TITLE
chore: remove hard-coded volume from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,8 +54,6 @@ ENV WAKAPI_ALLOW_SIGNUP 'true'
 
 COPY --from=build-env /app .
 
-VOLUME /data
-
 EXPOSE 3000
 
 ENTRYPOINT /app/entrypoint.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,3 +22,8 @@ services:
       POSTGRES_USER: "wakapi"
       POSTGRES_PASSWORD: "choose-a-password"
       POSTGRES_DB: "wakapi"
+    volumes:
+      - wakapi-db-data:/var/lib/postgresql/data
+
+volumes:
+  wakapi-db-data: {}


### PR DESCRIPTION
the Dockerfile has a `VOLUME /data` defined. However, there are multiple reasons to skip this:

1) volumes can be (are expected to be?) defined when running with `docker run` or `docker-compose`
2) this volume is unnecessary and not useful if sqlite db backend is not being used
3) it is easier to define a volume as needed than to _undefine_ a hard-coded volume
4) this creates lots of stale volumes during repeated builds with docker or compose

also, [the readme](https://github.com/muety/wakapi#-option-3-use-docker) already shows a `docker run` command complete with volume definition, and the `docker-compose.yml` in this PR defines a persistent volume for db data.