### PR TITLE
Fix wrong url in setup instructions

### DIFF
--- a/views/summary.tpl.html
+++ b/views/summary.tpl.html
@@ -198,7 +198,7 @@
                     # <strong>Step 2:</strong> Set your ~/.wakatime.cfg to this:<br><br>
                     <!-- https://github.com/muety/wakapi/issues/224#issuecomment-890855563 -->
                     [settings]<br>
-                    api_url = <span class="with-url-inner">%s/api</span><br>
+                    api_url = <span class="with-url-inner">%s/api/heartbeat</span><br>
                     api_key = <span id="api-key-instruction">{{ .ApiKey }}</span><br><br>
 
                     # <strong>Step 3:</strong> Start coding and then check back here!


### PR DESCRIPTION
I've spent hours trying to figure out why I got a 401 and 404. The issues was that the help test on the index page is not the same as the one in the readme