### PR TITLE
add Mayhem for API as a github workflow

### DIFF
--- a/.github/workflows/mapi.yml
+++ b/.github/workflows/mapi.yml
@@ -1,0 +1,52 @@
+name: 'Mayhem for API'
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+    steps:
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: ^1.18
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Get dependencies
+      run: go get
+
+    - name: Build
+      run: GO111MODULE=on go build -v .
+
+    - name: start wakapi
+      run: ./wakapi --config config.default.yml &
+
+    - name: create a trivial testing user
+      run: sqlite3 wakapi_db.db "insert into users (id, api_key) values ('mapi', 'test-api-key')"
+
+    - name: Run Mayhem for API
+      uses: ForAllSecure/mapi-action@v1
+      continue-on-error: true
+      with:
+        mapi-token: ${{ secrets.MAPI_TOKEN }}
+        api-url: http://localhost:3000/api/
+        api-spec: static/docs/swagger.yaml
+        target: mayhemheroes/wakapi
+        duration: 1min
+        sarif-report: mapi.sarif
+        run-args: |
+          --header-auth
+          Authorization: Basic dGVzdC1hcGkta2V5
+
+    - name: Upload SARIF file
+      uses: github/codeql-action/upload-sarif@v1
+      with:
+        sarif_file: mapi.sarif


### PR DESCRIPTION
Add a github action to run [Mayhem for API](https://mayhem4api.forallsecure.com/) (which is a free automated testing tool for http APIs) against the api: given the swagger spec and api server, it generates and runs random test payloads, looking for exceptional behavior.

Disclosure: working on this tool is my day job!

As with any github workflow, test results can be consumed through github. Alternatively, Mayhem for API also has a dashboard, over here: https://mayhem4api.forallsecure.com/mayhemheroes/wakapi.

Currently this finds a bunch of Internal Server Errors that can be pretty easily triggered, an Authentication Bypass (unauthenticated success against an endpoint which the spec says requires auth), and a (seemingly consistently reproducible) timeout.

To make it work in the upstream repo, there's a bit of out-of-PR effort to integrate:

- sign up for a free mapi account, creating an muety organization
- create a mapi service account within the muety organization
- modify the mapi.yaml action in this PR to point at your mapi organization
- add the service account's API token to github as a repository secret named MAPI_TOKEN