### PR TITLE
add last_year and all_time interval identifier like in wakatime docs

### DIFF
--- a/models/interval.go
+++ b/models/interval.go
@@ -14,8 +14,8 @@ var (
 	IntervalPast7DaysYesterday = &IntervalKey{"Last 7 Days from Yesterday"}
 	IntervalPast14Days         = &IntervalKey{"Last 14 Days"}
 	IntervalPast30Days         = &IntervalKey{"30_days", "last_30_days", "Last 30 Days"}
-	IntervalPast12Months       = &IntervalKey{"12_months", "last_12_months"}
-	IntervalAny                = &IntervalKey{"any"}
+	IntervalPast12Months       = &IntervalKey{"12_months", "last_12_months", "last_year"}
+	IntervalAny                = &IntervalKey{"any", "all_time"}
 )
 
 var AllIntervals = []*IntervalKey{


### PR DESCRIPTION
This PR add two identifier for the duration in the api. Because the ones for 12 months and any are [not like in Wakatime documentation](https://wakatime.com/developers#stats) and can cause error when using tools made for Wakatime.
For exemple [Metrics](https://github.com/lowlighter/metrics) uses [last_year](https://github.com/lowlighter/metrics/blob/7e4bab7d85c7d114cc928299765f830c107270a4/source/plugins/wakatime/index.mjs#L21) to get the data for 365 days.