### PR TITLE
Add postgres DSN config option

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -98,6 +98,7 @@ type dbConfig struct {
 	Dialect                 string `yaml:"-"`
 	Charset                 string `default:"utf8mb4" env:"WAKAPI_DB_CHARSET"`
 	Type                    string `yaml:"dialect" default:"sqlite3" env:"WAKAPI_DB_TYPE"`
+	DSN                     string `yaml:"DSN" default:"" env:"WAKAPI_DB_DSN"`
 	MaxConn                 uint   `yaml:"max_conn" default:"2" env:"WAKAPI_DB_MAX_CONNECTIONS"`
 	Ssl                     bool   `default:"false" env:"WAKAPI_DB_SSL"`
 	AutoMigrateFailSilently bool   `yaml:"automigrate_fail_silently" default:"false" env:"WAKAPI_DB_AUTOMIGRATE_FAIL_SILENTLY"`

--- a/config/db.go
+++ b/config/db.go
@@ -66,6 +66,10 @@ func mysqlConnectionString(config *dbConfig) string {
 }
 
 func postgresConnectionString(config *dbConfig) string {
+	if len(config.DSN) > 0 {
+		return config.DSN
+	}
+
 	sslmode := "disable"
 	if config.Ssl {
 		sslmode = "require"


### PR DESCRIPTION
Allows specifiying a raw DSN (currently only used for dialect: postgres, not sure it makes sense for other database types). Resolves https://github.com/muety/wakapi/issues/423