### PR TITLE
Upgrade testing for SQLite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,4 +117,4 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Run sqlite
-      run: ./testing/run_api_tests.sh sqlite y
+      run: ./testing/run_api_tests.sh sqlite --migration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,3 +101,20 @@ jobs:
 
     - name: Build
       run: go build -v .
+
+  migration:
+    name: Migration tests
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: ^1.19
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Run sqlite
+      run: ./testing/run_api_tests.sh sqlite y

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ wakapi
 build
 *.exe
 *.db
+*.zip
 config*.yml
 !config.default.yml
 !testing/config.testing.yml

--- a/testing/run_api_tests.sh
+++ b/testing/run_api_tests.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
-
-echo "Compiling."
-CGO_ENABLED=0 go build
+set -e
 
 if ! command -v newman &> /dev/null
 then
@@ -9,25 +7,60 @@ then
     exit 1
 fi
 
-cd "$(dirname "$0")"
+script_path=$(realpath "${BASH_SOURCE[0]}")
+script_dir=$(dirname "$script_path")
 
-echo "Creating database and schema ..."
-sqlite3 wakapi_testing.db < schema.sql
+echo "Compiling."
+(cd "$script_dir/.." || exit 1; CGO_ENABLED=0 go build)
 
-echo "Importing seed data ..."
-sqlite3 wakapi_testing.db < data.sql
+cd "$script_dir" || exit 1
 
+# Download previous release (when upgrade testing)
+INITIAL_RUN_EXE="../wakapi"
+if [[ "$2" == "y" ]]; then
+    if [ ! -f wakapi_linux_amd64.zip ]; then
+        curl https://github.com/muety/wakapi/releases/latest/download/wakapi_linux_amd64.zip -O -L
+    fi
+    unzip -o wakapi_linux_amd64.zip
+    INITIAL_RUN_EXE="./wakapi"
+    echo "Running tests with release version"
+fi
+
+# Initialise test data
+case $1 in
+    sqlite|*)
+    rm -f wakapi_testing.db
+
+    echo "Creating database and schema ..."
+    sqlite3 wakapi_testing.db < schema.sql
+
+    echo "Importing seed data ..."
+    sqlite3 wakapi_testing.db < data.sql
+
+    CONFIG="config.testing.yml"
+    ;;
+esac
+
+wait_for_wakapi () {
+    counter=0
+    echo "Waiting for Wakapi to come up ..."
+    until curl --output /dev/null --silent --get --fail http://localhost:3000/api/health; do
+        if [ "$counter" -ge 5 ]; then
+            echo "Waited for 5s, but Wakapi failed to come up ..."
+            exit 1
+        fi
+
+        printf '.'
+        sleep 1
+        counter=$((counter+1))
+    done
+    printf "\n"
+}
+
+# Run tests
 echo "Running Wakapi testing instance in background ..."
-../wakapi -config config.testing.yml &
+"$INITIAL_RUN_EXE" -config "$CONFIG" &
 pid=$!
-
-echo "Waiting for Wakapi to come up ..."
-until $(curl --output /dev/null --silent --get --fail http://localhost:3000/api/health); do
-    printf '.'
-    sleep 1
-done
-
-echo ""
 
 echo "Running test collection ..."
 newman run "wakapi_api_tests.postman_collection.json"
@@ -36,7 +69,16 @@ exit_code=$?
 echo "Shutting down Wakapi ..."
 kill -TERM $pid
 
-echo "Deleting database ..."
-rm wakapi_testing.db
+# Run upgrade tests
+if [[ "$2" == "y" ]]; then
+    echo "Now running migrations with build"
+    ../wakapi -config "$CONFIG" &
+    pid=$!
 
+    wait_for_wakapi
+    echo "Shutting down Wakapi ..."
+    kill -TERM $pid
+fi
+
+echo "Exiting with status $exit_code"
 exit $exit_code


### PR DESCRIPTION
How it works:
1. Download release version of Wakapi
2. Run tests against release version
3. Run current build of wakapi
4. If the service can come up, it means that migrations succeeded

This PR also changes `run_api_tests.sh` to have two optional arguments database type and upgrade testing, which defaults to sqlite and no upgrade testing respectively. 

Part of #407