### PR TITLE
fix(metrics): warning - postgres - failed to get database size (expected 0 arguments, got 1)

### DIFF
--- a/repositories/metrics.go
+++ b/repositories/metrics.go
@@ -16,7 +16,7 @@ FROM information_schema.tables
 WHERE table_schema = ?
 GROUP BY table_schema`
 
-const sizeTplPostgres = `SELECT pg_database_size('%s');`
+const sizeTplPostgres = `SELECT pg_database_size(?);`
 
 const sizeTplSqlite = `
 SELECT page_count * page_size as size


### PR DESCRIPTION
Hello, I've just enabled metrics and noticed this warning, so I've prepared a fix.