### PR TITLE
fix: invalid search query in Postgres

### DIFF
--- a/repositories/key_value.go
+++ b/repositories/key_value.go
@@ -2,6 +2,7 @@ package repositories
 
 import (
 	"errors"
+	"github.com/muety/wakapi/config"
 	"github.com/muety/wakapi/models"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -36,8 +37,12 @@ func (r *KeyValueRepository) GetString(key string) (*models.KeyStringValue, erro
 
 func (r *KeyValueRepository) Search(like string) ([]*models.KeyStringValue, error) {
 	var keyValues []*models.KeyStringValue
+	condition := "key like ?"
+	if r.db.Config.Name() == config.SQLDialectMysql {
+		condition = "`key` like ?"
+	}
 	if err := r.db.Table("key_string_values").
-		Where("`key` like ?", like).
+		Where(condition, like).
 		Find(&keyValues).
 		Error; err != nil {
 		return nil, err


### PR DESCRIPTION
Remove ` to avoid syntax errors in PostgreSQL.

```
psql (15.3 (Debian 15.3-1.pgdg110+1))
Type "help" for help.

wakapi=> select * from key_string_values where `key` like '2021%';
ERROR:  operator does not exist: ` text
LINE 1: select * from key_string_values where `key` like '2021%';
                                              ^
HINT:  No operator matches the given name and argument type. You might need to add an explicit type cast.
wakapi=> select * from key_string_values where key like '2021%';
                       key                        | value
--------------------------------------------------+-------
 20210213-add_has_data_field                      | done
 20210221-add_created_date_column                 | done
 20210411-add_imprint_content                     | done
 20210202-fix_cascade_for_alias_user_constraint   | done
 20211215-migrate_id_to_bigint-add_has_data_field | done
 20210806-remove_persisted_project_labels         | done
 20212212-total_summary_heartbeats                | done
(7 rows)
```