### PR TITLE
ci(release): update to ubuntu-latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - platform: ubuntu-18.04
+          - platform: ubuntu-latest
             GOOS: linux
             GOARCH: amd64
-          - platform: ubuntu-18.04
+          - platform: ubuntu-latest
             GOOS: linux
             GOARCH: arm64
           - platform: windows-latest


### PR DESCRIPTION
ubuntu-18.04 has been deprecated.
https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/

I think we downgraded to 18.04 at some point due to glibc, but this is perhaps not relevant any more after #408?