### PR TITLE
ci: reduce permissions for non-release actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,9 @@ jobs:
   test:
     name: 'Unit- & API tests'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-
     - name: Set up Go 1.x
       uses: actions/setup-go@v3
       with:
@@ -32,6 +33,8 @@ jobs:
   migration:
     name: Migration tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
See "Use credentials that are minimally scoped" in https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-secrets
https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token

Note that `GITHUB_TOKEN` does require more privileges for release actions (e.g. for pushing docker image). 
However, there's probably less risk there given that those pipelines are only triggered on release. 