### PR TITLE
feat: added fields in projects api

### DIFF
--- a/models/compat/wakatime/v1/project.go
+++ b/models/compat/wakatime/v1/project.go
@@ -1,11 +1,16 @@
 package v1
 
+import "time"
+
 type ProjectsViewModel struct {
 	Data []*Project `json:"data"`
 }
 
 type Project struct {
-	ID         string `json:"id"`
-	Name       string `json:"name"`
-	Repository string `json:"repository"`
+	ID                           string    `json:"id"`
+	Name                         string    `json:"name"`
+	LastHeartbeatAt              time.Time `json:"last_heartbeat_at"`
+	HumanReadableLastHeartbeatAt string    `json:"human_readable_last_heartbeat_at"`
+	UrlencodedName               string    `json:"urlencoded_name"`
+	CreatedAt                    time.Time `json:"created_at"`
 }


### PR DESCRIPTION
Added fields in Project model for WakaTime compat API:
 - `last_heartbeat_at`
 - `human_readable_last_heartbeat_at`
 - `urlencoded_name`
 - `created_at`

I removed the `repository` field because I saw that there is no implementation. It used to return an empty string, which does not reflects the WakaTime implementation, because it's either null or an object. After #33 gets solved, I think it could be added again.