### PR TITLE
feat: add leaders endpoint

### DIFF
--- a/main.go
+++ b/main.go
@@ -223,6 +223,7 @@ func main() {
 	wakatimeV1UsersHandler := wtV1Routes.NewUsersHandler(userService, heartbeatService)
 	wakatimeV1ProjectsHandler := wtV1Routes.NewProjectsHandler(userService, heartbeatService)
 	wakatimeV1HeartbeatsHandler := wtV1Routes.NewHeartbeatHandler(userService, heartbeatService)
+	wakatimeV1LeadersHandler := wtV1Routes.NewLeadersHandler(userService, leaderboardService)
 	shieldV1BadgeHandler := shieldsV1Routes.NewBadgeHandler(summaryService, userService)
 
 	// MVC Handlers
@@ -294,6 +295,7 @@ func main() {
 	wakatimeV1UsersHandler.RegisterRoutes(apiRouter)
 	wakatimeV1ProjectsHandler.RegisterRoutes(apiRouter)
 	wakatimeV1HeartbeatsHandler.RegisterRoutes(apiRouter)
+	wakatimeV1LeadersHandler.RegisterRoutes(apiRouter)
 	shieldV1BadgeHandler.RegisterRoutes(apiRouter)
 
 	// Static Routes

--- a/models/compat/wakatime/v1/leaders.go
+++ b/models/compat/wakatime/v1/leaders.go
@@ -1,0 +1,97 @@
+package v1
+
+import (
+	"github.com/duke-git/lancet/v2/slice"
+	"github.com/muety/wakapi/models"
+	"time"
+)
+
+// partially compatible with https://wakatime.com/developers#leaders
+
+type LeaderboardViewModel struct {
+	CurrentUser CurrentUser        `json:"current_user"`
+	Data        []LeaderboardEntry `json:"data"`
+}
+
+type CurrentUser struct {
+	Rank int   `json:"rank"`
+	Page int   `json:"page"`
+	User *User `json:"user"`
+}
+
+type LeaderboardEntry struct {
+	Rank         int          `json:"rank"`
+	RunningTotal RunningTotal `json:"running_total"`
+	User         *User        `json:"user"`
+}
+
+type RunningTotal struct {
+	TotalSeconds              float64    `json:"total_seconds"`
+	HumanReadableTotal        string     `json:"human_readable_total"`
+	DailyAverage              float64    `json:"daily_average"`
+	HumanReadableDailyAverage string     `json:"human_readable_daily_average"`
+	Languages                 []Language `json:"languages"`
+}
+
+type Language struct {
+	Name         string  `json:"name"`
+	TotalSeconds float64 `json:"total_seconds"`
+}
+
+func NewRunningTotal(entry *models.LeaderboardItemRanked) RunningTotal {
+	return RunningTotal{
+		TotalSeconds:              entry.Total.Seconds(),
+		HumanReadableTotal:        entry.Total.String(),
+		DailyAverage:              entry.Total.Seconds() / 7,
+		HumanReadableDailyAverage: (entry.Total / 7).String(),
+		Languages:                 []Language{},
+	}
+}
+
+func NewLeaderboardEntry(entry *models.LeaderboardItemRanked) LeaderboardEntry {
+	return LeaderboardEntry{
+		Rank:         int(entry.Rank),
+		RunningTotal: NewRunningTotal(entry),
+		User:         NewFromUser(entry.User),
+	}
+}
+
+func NewLeaderboardViewModel(leaderboard *models.Leaderboard, user *models.User) *LeaderboardViewModel {
+	var entries []LeaderboardEntry
+	var currentUserEntry = CurrentUser{}
+	for _, entry := range *leaderboard {
+		if user != nil && entry.User.ID == user.ID {
+			currentUserEntry = CurrentUser{
+				Rank: int(entry.Rank),
+				Page: 0,
+				User: NewFromUser(user),
+			}
+		}
+
+		if foundEntry, found := slice.Find[LeaderboardEntry](entries, func(i int, entry2 LeaderboardEntry) bool {
+			return entry2.User.ID == entry.User.ID
+		}); found {
+			foundEntry.RunningTotal.Languages = append(foundEntry.RunningTotal.Languages, Language{
+				Name:         *entry.Key,
+				TotalSeconds: entry.Total.Seconds(),
+			})
+			foundEntry.RunningTotal.TotalSeconds += entry.Total.Seconds()
+			foundEntry.RunningTotal.DailyAverage = foundEntry.RunningTotal.TotalSeconds / 7
+			var totalDuration time.Duration = time.Duration(foundEntry.RunningTotal.TotalSeconds) * time.Second
+			foundEntry.RunningTotal.HumanReadableTotal = totalDuration.String()
+			foundEntry.RunningTotal.HumanReadableDailyAverage = (totalDuration / 7).String()
+
+			entries = slice.Filter[LeaderboardEntry](entries, func(i int, entry2 LeaderboardEntry) bool {
+				return entry2.User.ID != entry.User.ID
+			})
+			entries = append(entries, *foundEntry)
+			continue
+		}
+		entries = append(entries, NewLeaderboardEntry(entry))
+	}
+
+	return &LeaderboardViewModel{
+		CurrentUser: currentUserEntry,
+		Data:        entries,
+	}
+}

--- a/routes/compat/wakatime/v1/leaders.go
+++ b/routes/compat/wakatime/v1/leaders.go
@@ -1,0 +1,82 @@
+package v1
+
+import (
+	"github.com/go-chi/chi/v5"
+	"github.com/muety/wakapi/helpers"
+	"github.com/muety/wakapi/middlewares"
+	"github.com/muety/wakapi/models"
+	"github.com/muety/wakapi/utils"
+	"net/http"
+
+	conf "github.com/muety/wakapi/config"
+	v1 "github.com/muety/wakapi/models/compat/wakatime/v1"
+	"github.com/muety/wakapi/services"
+)
+
+type LeadersHandler struct {
+	config          *conf.Config
+	userSrvc        services.IUserService
+	leaderboardSrvc services.ILeaderboardService
+}
+
+func NewLeadersHandler(userService services.IUserService, leaderboardService services.ILeaderboardService) *LeadersHandler {
+	return &LeadersHandler{
+		userSrvc:        userService,
+		leaderboardSrvc: leaderboardService,
+		config:          conf.Get(),
+	}
+}
+
+func (h *LeadersHandler) RegisterRoutes(router chi.Router) {
+	router.Group(func(r chi.Router) {
+		r.Use(middlewares.NewAuthenticateMiddleware(h.userSrvc).Handler)
+		r.Get("/compat/wakatime/v1/leaders", h.Get)
+	})
+}
+
+// @Summary List of users ranked by coding activity in descending order.
+// @Description Mimics https://wakatime.com/developers#leaders
+// @ID get-wakatime-leaders
+// @Tags wakatime
+// @Produce json
+// @Security ApiKeyAuth
+// @Success 200 {object} v1.LeaderboardViewModel
+// @Router /compat/wakatime/v1/leaders [get]
+func (h *LeadersHandler) Get(w http.ResponseWriter, r *http.Request) {
+	wakapiUser, err := h.userSrvc.GetUserById("current")
+	if err != nil {
+		conf.Log().Request(r).Error("error while fetching user - %v", err)
+		helpers.RespondJSON(w, r, http.StatusInternalServerError, nil)
+		return
+	}
+	pageParams := utils.ParsePageParamsWithDefault(r, 1, 100)
+
+	/*
+		Not implemented query params:
+			language - String - optional - Filter leaders by a specific language.
+			is_hireable - Boolean - optional - Filter leaders by the hireable badge.
+			country_code - String - optional - Filter leaders by two-character country code.
+			page - Integer - optional - Page number of leaderboard. If authenticated, defaults to the page containing the currently authenticated user.
+	*/
+
+	by := models.SummaryLanguage
+	leaderboard, err := h.leaderboardSrvc.GetAggregatedByInterval(models.IntervalPast7Days, &by, pageParams, true)
+	if err != nil {
+		conf.Log().Request(r).Error("error while fetching general leaderboard items - %v", err)
+		helpers.RespondJSON(w, r, http.StatusInternalServerError, nil)
+		return
+	}
+
+	// regardless of page, always show own rank
+	if wakapiUser != nil && !leaderboard.HasUser(wakapiUser.ID) {
+		// but only if leaderboard spans multiple pages
+		if count, err := h.leaderboardSrvc.CountUsers(); err == nil && count > int64(pageParams.PageSize) {
+			if l, err := h.leaderboardSrvc.GetByIntervalAndUser(models.IntervalPast7Days, wakapiUser.ID, true); err == nil && len(l) > 0 {
+				leaderboard = append(leaderboard, l[0])
+			}
+		}
+	}
+
+	user := v1.NewLeaderboardViewModel(&leaderboard, wakapiUser)
+	helpers.RespondJSON(w, r, http.StatusOK, user)
+}

--- a/static/docs/swagger.json
+++ b/static/docs/swagger.json
@@ -516,6 +516,76 @@
                 }
             }
         },
+        "/compat/wakatime/v1/leaders": {
+            "get": {
+                "security": [
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "description": "Mimics https://wakatime.com/developers#leaders",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "wakatime"
+                ],
+                "summary": "Retrieve the global leaderboard",
+                "operationId": "get-wakatime-leaders",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Range interval identifier",
+                        "name": "range",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Project to filter by",
+                        "name": "project",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Language to filter by",
+                        "name": "language",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Editor to filter by",
+                        "name": "editor",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "OS to filter by",
+                        "name": "operating_system",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Machine to filter by",
+                        "name": "machine",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Project label to filter by",
+                        "name": "label",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/v1.LeadersViewModel"
+                        }
+                    }
+                }
+            }
+        },
         "/health": {
             "get": {
                 "produces": [
@@ -1675,6 +1745,70 @@
             "properties": {
                 "data": {
                     "$ref": "#/definitions/v1.User"
+                }
+            }
+        },
+        "v1.LeadersViewModel": {
+            "type": "object",
+            "properties": {
+                "current_user": {
+                    "type": "object",
+                    "properties": {
+                        "rank": {
+                            "type": "integer"
+                        },
+                        "page": {
+                            "type": "integer"
+                        },
+                        "user": {
+                            "$ref": "#/definitions/v1.User"
+                        }
+                    }
+                },
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "rank": {
+                                "type": "integer"
+                            },
+                            "running_total": {
+                                "type": "object",
+                                "properties": {
+                                    "daily_average": {
+                                        "type": "number"
+                                    },
+                                    "human_readable_daily_average": {
+                                        "type": "string"
+                                    },
+                                    "human_readable_total": {
+                                        "type": "string"
+                                    },
+                                    "languages": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "name": {
+                                                    "type": "string"
+                                                },
+                                                "total_seconds": {
+                                                    "type": "number"
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "total_seconds": {
+                                        "type": "number"
+                                    }
+                                }
+                            },
+                            "user": {
+                                "$ref": "#/definitions/v1.User"
+                            }
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
This PR adds the [leaders](https://wakatime.com/developers#leaders) endpoint from Wakatime to `api/compat/wakatime/v1/leaders`

Example response:
```json
{
	"current_user": {
		"rank": 1,
		"page": 0,
		"user": {
			"id": "Subtixx",
			"display_name": "Anonymous User",
			"full_name": "",
			"email": "admin@local.host",
			"is_email_public": false,
			"is_email_confirmed": false,
			"timezone": "Europe/Berlin",
			"last_heartbeat_at": "0001-01-01T00:00:00Z",
			"last_project": "",
			"last_plugin_name": "",
			"username": "Subtixx",
			"website": "",
			"created_at": "2021-09-11T17:21:19+02:00",
			"modified_at": "2021-09-11T17:21:19+02:00"
		}
	},
	"data": [
		{
			"rank": 1,
			"running_total": {
				"total_seconds": 5332,
				"human_readable_total": "1h28m52s",
				"daily_average": 761.7142857142857,
				"human_readable_daily_average": "12m41.714285714s",
				"languages": [
					{
						"name": "Blade",
						"total_seconds": 5848
					},
					{
						"name": "Go",
						"total_seconds": 5538
					},
					{
						"name": "Java",
						"total_seconds": 5659
					},
					{
						"name": "JavaScript",
						"total_seconds": 6442
					},
					{
						"name": "PHP",
						"total_seconds": 5375
					},
					{
						"name": "Python",
						"total_seconds": 6100
					}
				]
			},
			"user": {
				"id": "Subtixx",
				"display_name": "Anonymous User",
				"full_name": "",
				"email": "admin@local.host",
				"is_email_public": false,
				"is_email_confirmed": false,
				"timezone": "Europe/Berlin",
				"last_heartbeat_at": "0001-01-01T00:00:00Z",
				"last_project": "",
				"last_plugin_name": "",
				"username": "Subtixx",
				"website": "",
				"created_at": "2021-09-11T17:21:19+02:00",
				"modified_at": "2021-09-11T17:21:19+02:00"
			}
		}
	]
}
```