### PR TITLE
fix: avatar url wrong url using external api

### DIFF
--- a/models/compat/wakatime/v1/user.go
+++ b/models/compat/wakatime/v1/user.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/muety/wakapi/config"
@@ -41,6 +42,12 @@ func NewFromUser(user *models.User) *User {
 		tz = user.Location
 	}
 
+	avatarURL := user.AvatarURL(cfg.App.AvatarURLTemplate)
+
+	if !strings.HasPrefix(avatarURL, "http") {
+		avatarURL = fmt.Sprintf("%s%s/%s", cfg.Server.GetPublicUrl(), cfg.Server.BasePath, avatarURL)
+	}
+
 	return &User{
 		ID:          user.ID,
 		DisplayName: user.ID,
@@ -49,7 +56,7 @@ func NewFromUser(user *models.User) *User {
 		Username:    user.ID,
 		CreatedAt:   user.CreatedAt,
 		ModifiedAt:  user.CreatedAt,
-		Photo:       fmt.Sprintf("%s%s/%s", cfg.Server.GetPublicUrl(), cfg.Server.BasePath, user.AvatarURL(cfg.App.AvatarURLTemplate)),
+		Photo:       avatarURL,
 	}
 }
 


### PR DESCRIPTION
When using an external API service (like Gravatar) the avatar URL returned from `/api/compat/wakatime/v1/users/current` is wrong: `http://localhost:3000/https://gravatar.com/avatar/3c90a086090c74081892efea2f523658`.

This PR checks if the returned URL from User.AvatarURL() is an URL or a path.