### PR TITLE
allow empty version in user agent regex for KDE Kate

### DIFF
--- a/utils/collection_test.go
+++ b/utils/collection_test.go
@@ -50,6 +50,12 @@ func TestCommon_ParseUserAgent(t *testing.T) {
 			nil,
 		},
 		{
+			"wakatime/ (Linux-6.0.42-1-lts-foobar-x86_64) KTextEditor/5.111.0 kate-wakatime/1.3.10",
+			"Linux",
+			"kate",
+			nil,
+		},
+		{
 			"Chrome/111.0.0.0 chrome-wakatime/3.0.6",
 			"",
 			"chrome",

--- a/utils/http.go
+++ b/utils/http.go
@@ -85,7 +85,7 @@ func ParsePageParamsWithDefault(r *http.Request, page, size int) *PageParams {
 
 func ParseUserAgent(ua string) (string, string, error) { // os, editor, err
 	// try parse wakatime client user agents
-	re := regexp.MustCompile(`(?iU)^(?:(?:wakatime|chrome|firefox|edge)\/(?:v?[\d+.]+|unset)\s)?(?:\(?(\w+)[-_].*\)?.+\s)?([^\/\s]+)-wakatime\/.+$`)
+	re := regexp.MustCompile(`(?iU)^(?:(?:wakatime|chrome|firefox|edge)\/(?:v?[\d+.]+|unset)?\s)?(?:\(?(\w+)[-_].*\)?.+\s)?([^\/\s]+)-wakatime\/.+$`)
 	if groups := re.FindAllStringSubmatch(ua, -1); len(groups) > 0 && len(groups[0]) == 3 {
 		if groups[0][1] == "win" {
 			groups[0][1] = "windows"


### PR DESCRIPTION
My KDE Kate installation with the officially endorsed plugin generates UA strings like `wakatime/ (Linux-6.XX-HOSTNAME-x86_64) KTextEditor/5.111.0 kate-wakatime/1.3.10`