### PR TITLE
perf: avoid allocations with `(*regexp.Regexp).MatchString`

### DIFF
--- a/models/mail_address.go
+++ b/models/mail_address.go
@@ -48,7 +48,7 @@ func (m MailAddress) Domain() string {
 }
 
 func (m MailAddress) Valid() bool {
-	return emailAddrRegex.Match([]byte(m))
+	return emailAddrRegex.MatchString(string(m))
 }
 
 func (m MailAddresses) Strings() []string {

--- a/models/user.go
+++ b/models/user.go
@@ -198,7 +198,7 @@ func ValidatePassword(password string) bool {
 
 // ValidateEmail checks that, if an email address is given, it has proper syntax and (if not in dev mode) an MX record exists for the domain
 func ValidateEmail(email string) bool {
-	return email == "" || (mailRegex.Match([]byte(email)) && (conf.Get().IsDev() || utils.CheckEmailMX(email)))
+	return email == "" || (mailRegex.MatchString(email) && (conf.Get().IsDev() || utils.CheckEmailMX(email)))
 }
 
 func ValidateTimezone(tz string) bool {

--- a/scripts/email_checker.go
+++ b/scripts/email_checker.go
@@ -31,7 +31,7 @@ func CheckEmailMX(email string) bool {
 }
 
 func ValidateEmail(email string) bool {
-	return mailRegex.Match([]byte(email)) && CheckEmailMX(email)
+	return mailRegex.MatchString(email) && CheckEmailMX(email)
 }
 
 func main() {


### PR DESCRIPTION
We should use `(*regexp.Regexp).MatchString` instead of `(*regexp.Regexp).Match([]byte(...))` when matching string to avoid unnecessary `[]byte` conversions and reduce allocations. A one-line change for free performance improvement.

Example benchmark:

```go
func BenchmarkMatch(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if match := emailAddrRegex.Match([]byte("email@example.com")); !match {
			b.Fail()
		}
	}
}

func BenchmarkMatchString(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if match := emailAddrRegex.MatchString("email@example.com"); !match {
			b.Fail()
		}
	}
}
```

Result:

```
goos: linux
goarch: amd64
pkg: github.com/muety/wakapi/models
cpu: AMD Ryzen 7 PRO 4750U with Radeon Graphics
BenchmarkMatch-16          	 1149106	      1012 ns/op	      24 B/op	       1 allocs/op
BenchmarkMatchString-16    	 1566058	       727.8 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/muety/wakapi/models	3.521s
```