### PR TITLE
Updated SALT command syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ $ eget muety/wakapi
 # Create a persistent volume
 $ docker volume create wakapi-data
 
-$ SALT="$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w ${1:-32} | head -n 1)"
+$ SALT="$(cat /dev/urandom | LC_ALL=C tr -dc 'a-zA-Z0-9' | fold -w ${1:-32} | head -n 1)"
 
 # Run the container
 $ docker run -d \


### PR DESCRIPTION
<img width="678" alt="Screenshot 2023-12-24 at 03 06 17" src="https://github.com/muety/wakapi/assets/37969970/2d16951b-8043-4b7d-9919-788021dc44ac">

In MacOS Sonoma error appears that the `tr` command is encountering some bytes in the `/dev/urandom` output that are not valid. The `/dev/urandom` device produces random bytes.
When you pipe this to tr, it expects input that is valid text in your current locale. However, urandom may produce bytes that are not valid.

The `LC_ALL=C` sets the locale to C, which handles any byte values. Now should not complain about illegal byte sequences anymore. This will generate a random alphanumeric string.

Tested on MacOS and Ubuntu. In the left picture is MacOS, the right is Ubuntu
<img width="1710" alt="Screenshot 2023-12-24 at 03 09 29" src="https://github.com/muety/wakapi/assets/37969970/08dfb0dd-b4fd-452b-b6bb-6b8f51a1d6ee">

So this doesn't break anything
