### PR TITLE
Fix entity filter

### DIFF
--- a/static/assets/js/components/entity-filter.js
+++ b/static/assets/js/components/entity-filter.js
@@ -9,7 +9,7 @@ function EntityFilter({type, options, selection}) {
             return this.type.capitalize()
         },
         onSelectionUpdated(e) {
-            this.selection = e.target.value
+            this.selection = e.target.value == 'null' ? null : e.target.value
             this.$nextTick(() => {
                 const query = new URLSearchParams(window.location.search)
                 if (this.selection) query.set(type, this.selection)

--- a/static/assets/js/components/entity-filter.js
+++ b/static/assets/js/components/entity-filter.js
@@ -9,6 +9,7 @@ function EntityFilter({type, options, selection}) {
             return this.type.capitalize()
         },
         onSelectionUpdated(e) {
+            this.selection = e.target.value
             this.$nextTick(() => {
                 const query = new URLSearchParams(window.location.search)
                 if (this.selection) query.set(type, this.selection)


### PR DESCRIPTION
The dropdown menus to filter for project, language, machine, and label are not working because the selection on the EntityFilter is not updated when selecting a new value. This PR set the selection from the event target.