### PR TITLE
Special Docker push for 2.11.0

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,7 @@
 name: Publish Docker Image
 
 on:
+  workflow_dispatch:
   release:
     types:
       - published
@@ -15,9 +16,7 @@ jobs:
 
       - name: Set version
         run: |
-          (git describe --tags --exact-match \
-            || git symbolic-ref -q --short HEAD \
-            || git rev-parse --short HEAD) > version.txt 2> /dev/null
+          echo "2.11.0" > version.txt 2> /dev/null
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -25,18 +24,18 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      # - name: Login to DockerHub
+      #   uses: docker/login-action@v3
+      #   with:
+      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
+      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Log in to the Container registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Log in to the Container registry
+      #   uses: docker/login-action@v3
+      #   with:
+      #     registry: ghcr.io
+      #     username: ${{ github.actor }}
+      #     password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker Metadata
         id: meta
@@ -48,15 +47,15 @@ jobs:
           tags: |
             latest
             alpine
-            type=semver,pattern={{major}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{version}}
+            type=semver,pattern={{major}},value=2.11.0
+            type=semver,pattern={{major}}.{{minor}},value=2.11.0
+            type=semver,pattern={{version}},value=2.11.0
 
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
           context: .
           file: Dockerfile
-          push: true
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          push: false
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,18 +24,18 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # - name: Login to DockerHub
-      #   uses: docker/login-action@v3
-      #   with:
-      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
-      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # - name: Log in to the Container registry
-      #   uses: docker/login-action@v3
-      #   with:
-      #     registry: ghcr.io
-      #     username: ${{ github.actor }}
-      #     password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker Metadata
         id: meta
@@ -56,6 +56,6 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          push: false
+          push: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
https://github.com/YC/wakapi/actions/runs/8493918515/job/23268493429

The output of tags seems correct:
```
/usr/bin/docker buildx build --file Dockerfile --iidfile /home/runner/work/_temp/docker-actions-toolkit-hxGaLq/iidfile --platform linux/amd64,linux/arm64 --provenance mode=max,builder-id=https://github.com/YC/wakapi/actions/runs/8493918515 --tag ghcr.io/yc/wakapi:2 --tag ghcr.io/yc/wakapi:2.11 --tag ghcr.io/yc/wakapi:2.11.0 --tag ghcr.io/yc/wakapi:latest --tag ghcr.io/yc/wakapi:alpine --tag ghcr.io/yc/wakapi:latest --tag n1try/wakapi:2 --tag n1try/wakapi:2.11 --tag n1try/wakapi:2.11.0 --tag n1try/wakapi:latest --tag n1try/wakapi:alpine --tag n1try/wakapi:latest --metadata-file /home/runner/work/_temp/docker-actions-toolkit-hxGaLq/metadata-file .
```