### PR TITLE
Fix permissions of /app folder for sqlite in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ FROM alpine:3
 WORKDIR /app
 
 RUN addgroup -g 1000 app && \
-    adduser -u 1000 -G app -s /bin/sh -D app && \
+    adduser -u 1000 -G app -s /bin/sh -D app && chown app -R /app && \
     apk add --no-cache bash ca-certificates tzdata
 
 # See README.md and config.default.yml for all config options


### PR DESCRIPTION
I am trying to run sqlite in docker and was getting the same error as shown in issue #526. The app user does not own the /app directory, and so the it cannot create/open the sqlite file that sits in there. This isn't an issue when using postgres/mysql, but it is when you use a file based db.

This PR sets the /app directory's owner to app, so that the running user can modify the sqlite file