### PR TITLE
Improve badge integration sections

### DIFF
--- a/views/settings.tpl.html
+++ b/views/settings.tpl.html
@@ -708,25 +708,27 @@
                         <div class="flex gap-x-4 mt-4">
                             <div class="flex items-center w-1/3">
                                 <img class="with-url-src"
-                                     src="api/badge/{{ .User.ID }}/interval:30_days?label=last 30d"
+                                     src="api/badge/{{ .User.ID }}/interval:30_days?label=last%2030d"
                                      alt="Badge"
                                 />
                             </div>
                             <input
                                     class="with-url-value w-2/3 font-mono text-xs appearance-none bg-gray-850 text-gray-500 outline-none rounded py-2 px-4 cursor-not-allowed"
-                                    value="%s/api/badge/{{ .User.ID }}/{{ .User.ID }}/interval:30_days?label=last 30d"
+                                    value="%s/api/badge/{{ .User.ID }}/{{ .User.ID }}/interval:30_days?label=last%2030d"
                                     readonly>
                         </div>
 
                         <div class="flex gap-x-4 mt-4">
                             <div class="flex items-center w-1/3">
                                 <img class="with-url-src"
-                                     src="https://img.shields.io/endpoint?url=%s/api/compat/shields/v1/{{ .User.ID }}/interval:30_days&label=last 30d"
+                                     src="https://img.shields.io/endpoint?url=%s/api/compat/shields/v1/{{
+				     .User.ID }}/interval:30_days&label=last%2030d"
                                      alt="Shields.io badge"/>
                             </div>
                             <input
                                     class="with-url-value w-2/3 font-mono text-xs appearance-none bg-gray-850 text-gray-500 outline-none rounded py-2 px-4 cursor-not-allowed"
-                                    value="https://img.shields.io/endpoint?url=%s/api/compat/shields/v1/{{ .User.ID }}/interval:30_days&label=last 30d"
+                                    value="https://img.shields.io/endpoint?url=%s/api/compat/shields/v1/{{
+				    .User.ID }}/interval:30_days&label=last%2030d"
                                     readonly>
                         </div>
                         {{ end }}

--- a/views/settings.tpl.html
+++ b/views/settings.tpl.html
@@ -721,14 +721,12 @@
                         <div class="flex gap-x-4 mt-4">
                             <div class="flex items-center w-1/3">
                                 <img class="with-url-src"
-                                     src="https://img.shields.io/endpoint?url=%s/api/compat/shields/v1/{{
-				     .User.ID }}/interval:30_days&label=last%2030d"
+                                     src="https://img.shields.io/endpoint?url=%s/api/compat/shields/v1/{{ .User.ID }}/interval:all_time&label=All%20time&color=blue"
                                      alt="Shields.io badge"/>
                             </div>
                             <input
                                     class="with-url-value w-2/3 font-mono text-xs appearance-none bg-gray-850 text-gray-500 outline-none rounded py-2 px-4 cursor-not-allowed"
-                                    value="https://img.shields.io/endpoint?url=%s/api/compat/shields/v1/{{
-				    .User.ID }}/interval:30_days&label=last%2030d"
+                                    value="https://img.shields.io/endpoint?url=%s/api/compat/shields/v1/{{ .User.ID }}/interval:all_time&label=All%20time&color=blue"
                                     readonly>
                         </div>
                         {{ end }}


### PR DESCRIPTION
This pull request add URL encoding and make the two badges a bit more distinct.

When I was looking at the Badge section under integration, I was confused as to why the same badge was being displayed two times, without realizing one was a direct link to the current instance and the other links to shields.io using your instance's data. By making them a bit distinct, it could help remove that confusion when users first look at this section.

Also, by changing the space by a URL-encoded space in the link, it wont breaks the link when a user try to copy the badge link somewhere else.

Before:

<img width="479" alt="image" src="https://github.com/muety/wakapi/assets/25652765/6566c279-56c4-42b1-a6bf-74221c1e8135">

Copying the badge gives me ![badge](https://wakapi.notarock.lol/api/badge/notarock/notarock/interval:30_days?label=last 30d)

After:

<img width="491" alt="image" src="https://github.com/muety/wakapi/assets/25652765/edbc46d6-cfc2-42bc-b198-83ed06794481">

Copying the badge gives me ![badge](https://wakapi.notarock.lol/api/badge/notarock/notarock/interval:30_days?label=last%2030d)
