### PR TITLE
Ignore ID in incoming heartbeat requiest

### DIFF
--- a/models/heartbeat.go
+++ b/models/heartbeat.go
@@ -11,7 +11,7 @@ import (
 )
 
 type Heartbeat struct {
-	ID              uint64     `gorm:"primary_key" hash:"ignore"`
+	ID              uint64     `json:"-" gorm:"primary_key" hash:"ignore"`
 	User            *User      `json:"-" gorm:"not null; constraint:OnUpdate:CASCADE,OnDelete:CASCADE;" hash:"ignore"`
 	UserID          string     `json:"-" gorm:"not null; index:idx_time_user; index:idx_user_project"` // idx_user_project is for quickly fetching a user's project list (settings page)
 	Entity          string     `json:"Entity" gorm:"not null"`


### PR DESCRIPTION
[Browser extension](https://github.com/wakatime/browser-wakatime) sends heartbeat in such format

```json
[
  {
    "branch": "<<LAST_BRANCH>>",
    "category": "meeting",
    "entity": "https://meet.google.com",
    "id": "0014a80e-3a79-4bdd-a678-60e801ca7f58",
    "plugin": "Google Meet",
    "project": "xxx-xxxx-xxx",
    "time": "1728043575.398",
    "type": "domain",
    "userAgent": "Chrome/129.0.0.0 mac_arm64 chrome-wakatime/4.0.2"
  },
]
```

In wakapi there is 
```golang
type Heartbeat struct {
	ID              uint64     `gorm:"primary_key" hash:"ignore"`
        ...
}
```

So we need use uuid or don't accept any id from client

There is second solution in this PR