### PR TITLE
Remove circular dependency when logging configuration loading error

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"net"
 	"net/http"
 	"os"
@@ -471,7 +472,7 @@ func Get() *Config {
 func Load(configFlag string, version string) *Config {
 	config := &Config{}
 	if err := configor.New(&configor.Config{}).Load(config, configFlag); err != nil {
-		Log().Fatal("failed to read config", "error", err)
+		log.Fatal("failed to read config", err)
 	}
 
 	env = config.Env


### PR DESCRIPTION
Closes #689 

When the configuration fails to load properly, an error gets logged using `Log()`. This logger requires the configuration to be loaded properly to function. Calling `Log().fatal` when a configuration loading error occurs causes a panic which obstructs the configuration error and confuses users.

By downgrading to use the built in `log` package when handling this error, we can get some pretty valuable info on why the configuration has failed to load.

Before:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x8 pc=0x104b276a0]

goroutine 1 [running]:
github.com/muety/wakapi/config.(*Config).IsDev(...)
	/Users/notarock/src/wakapi/config/config.go:228
github.com/muety/wakapi/config.Log()
	/Users/notarock/src/wakapi/config/sentry.go:31 +0x30
github.com/muety/wakapi/config.Load({0x104d40ea7, 0xa}, {0x104d39d00, 0x4})
	/Users/notarock/src/wakapi/config/config.go:474 +0xbc
main.main()
	/Users/notarock/src/wakapi/main.go:122 +0x12c
exit status 2
```

After

```
2024/10/15 01:23:11 failed to read configyaml: unmarshal errors:
  line 14: cannot unmarshal !!str `tcp:80` into int
exit status 1
```