### PR TITLE
feat: add additional wakatime fields

### DIFF
--- a/models/heartbeat.go
+++ b/models/heartbeat.go
@@ -5,31 +5,39 @@ import (
 	"strings"
 	"time"
 
+	"log/slog"
+
 	"github.com/duke-git/lancet/v2/strutil"
 	"github.com/mitchellh/hashstructure/v2"
-	"log/slog"
 )
 
 type Heartbeat struct {
-	ID              uint64     `json:"-" gorm:"primary_key" hash:"ignore"`
-	User            *User      `json:"-" gorm:"not null; constraint:OnUpdate:CASCADE,OnDelete:CASCADE;" hash:"ignore"`
-	UserID          string     `json:"-" gorm:"not null; index:idx_time_user; index:idx_user_project"` // idx_user_project is for quickly fetching a user's project list (settings page)
-	Entity          string     `json:"entity" gorm:"not null"`
-	Type            string     `json:"type" gorm:"size:255"`
-	Category        string     `json:"category" gorm:"size:255"`
-	Project         string     `json:"project" gorm:"index:idx_project; index:idx_user_project"`
-	Branch          string     `json:"branch" gorm:"index:idx_branch"`
-	Language        string     `json:"language" gorm:"index:idx_language"`
-	IsWrite         bool       `json:"is_write"`
-	Editor          string     `json:"editor" gorm:"index:idx_editor" hash:"ignore"`                     // ignored because editor might be parsed differently by wakatime
-	OperatingSystem string     `json:"operating_system" gorm:"index:idx_operating_system" hash:"ignore"` // ignored because os might be parsed differently by wakatime
-	Machine         string     `json:"machine" gorm:"index:idx_machine" hash:"ignore"`                   // ignored because wakatime api doesn't return machines currently
-	UserAgent       string     `json:"user_agent" hash:"ignore" gorm:"type:varchar(255)"`
-	Time            CustomTime `json:"time" gorm:"timeScale:3; index:idx_time; index:idx_time_user" swaggertype:"primitive,number"`
-	Hash            string     `json:"-" gorm:"type:varchar(17); uniqueIndex"`
-	Origin          string     `json:"-" hash:"ignore" gorm:"type:varchar(255)"`
-	OriginId        string     `json:"-" hash:"ignore" gorm:"type:varchar(255)"`
-	CreatedAt       CustomTime `json:"created_at" gorm:"timeScale:3" swaggertype:"primitive,number" hash:"ignore"` // https://gorm.io/docs/conventions.html#CreatedAt
+	ID               uint64     `json:"-" gorm:"primary_key" hash:"ignore"`
+	User             *User      `json:"-" gorm:"not null; constraint:OnUpdate:CASCADE,OnDelete:CASCADE;" hash:"ignore"`
+	UserID           string     `json:"-" gorm:"not null; index:idx_time_user; index:idx_user_project"` // idx_user_project is for quickly fetching a user's project list (settings page)
+	Entity           string     `json:"entity" gorm:"not null"`
+	Type             string     `json:"type" gorm:"size:255"`
+	Category         string     `json:"category" gorm:"size:255"`
+	Project          string     `json:"project" gorm:"index:idx_project; index:idx_user_project"`
+	Branch           string     `json:"branch" gorm:"index:idx_branch"`
+	Language         string     `json:"language" gorm:"index:idx_language"`
+	IsWrite          bool       `json:"is_write"`
+	Editor           string     `json:"editor" gorm:"index:idx_editor" hash:"ignore"`                     // ignored because editor might be parsed differently by wakatime
+	OperatingSystem  string     `json:"operating_system" gorm:"index:idx_operating_system" hash:"ignore"` // ignored because os might be parsed differently by wakatime
+	Machine          string     `json:"machine" gorm:"index:idx_machine" hash:"ignore"`                   // ignored because wakatime api doesn't return machines currently
+	UserAgent        string     `json:"user_agent" hash:"ignore" gorm:"type:varchar(255)"`
+	Time             CustomTime `json:"time" gorm:"timeScale:3; index:idx_time; index:idx_time_user" swaggertype:"primitive,number"`
+	Hash             string     `json:"-" gorm:"type:varchar(17); uniqueIndex"`
+	Origin           string     `json:"-" hash:"ignore" gorm:"type:varchar(255)"`
+	OriginId         string     `json:"-" hash:"ignore" gorm:"type:varchar(255)"`
+	CreatedAt        CustomTime `json:"created_at" gorm:"timeScale:3" swaggertype:"primitive,number" hash:"ignore"` // https://gorm.io/docs/conventions.html#CreatedAt
+	Lines            *int       `json:"lines,omitempty" hash:"ignore"`
+	LineNo           *int       `json:"lineno,omitempty" hash:"ignore"`
+	CursorPos        *int       `json:"cursorpos,omitempty" hash:"ignore"`
+	LineDeletions    *int       `json:"line_deletions,omitempty" hash:"ignore"`
+	LineAdditions    *int       `json:"line_additions,omitempty" hash:"ignore"`
+	Dependencies     []string   `json:"dependencies,omitempty" gorm:"serializer:json;size:255" hash:"ignore"`
+	ProjectRootCount *int       `json:"project_root_count,omitempty"`
 }
 
 func (h *Heartbeat) Valid() bool {

--- a/models/heartbeat.go
+++ b/models/heartbeat.go
@@ -36,7 +36,6 @@ type Heartbeat struct {
 	CursorPos        *int       `json:"cursorpos,omitempty" hash:"ignore"`
 	LineDeletions    *int       `json:"line_deletions,omitempty" hash:"ignore"`
 	LineAdditions    *int       `json:"line_additions,omitempty" hash:"ignore"`
-	Dependencies     []string   `json:"dependencies,omitempty" gorm:"serializer:json;size:255" hash:"ignore"`
 	ProjectRootCount *int       `json:"project_root_count,omitempty"`
 }
 


### PR DESCRIPTION
Wakapi is a very useful tool, I have been using it to record my work time. Recently I found that Wakatime has some very useful fields that are very helpful for code analysis, but these fields are not recorded in Wakapi. This change is to add these fields in. 

These fields are

```
"dependencies": <string: comma separated list of dependencies detected from entity file (optional)>,
"lines": <integer: total number of lines in the entity (when entity type is file)>,
"line_additions": <integer: number of lines added since last heartbeat in the current file (optional)>,
"line_deletions": <integer: number of lines removed since last heartbeat in the current file (optional)>,
"lineno": <integer: current line row number of cursor with the first line starting at 1 (optional)>,
"cursorpos": <integer: current cursor column position starting from 1 (optional)>,
```

for all wakatime fields, please refer to https://wakatime.com/developers#heartbeats


