### PR TITLE
fix(config): reverse proxy ip ranges parse warning when unset

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -335,6 +335,11 @@ func (c *securityConfig) ParseTrustReverseProxyIPs() {
 	c.trustReverseProxyIpsParsed = make([]net.IPNet, 0)
 
 	for _, ip := range strings.Split(c.TrustReverseProxyIps, ",") {
+		// the config value is empty by default
+		if ip == "" {
+			continue
+		}
+
 		// try parse as address range
 		_, parsedIpNet, err := net.ParseCIDR(ip)
 		if err == nil {


### PR DESCRIPTION
When the `TrustReverseProxyIps` configuration option is unset, it is `""` by default. Thus, this empty string is still parsed at startup, leading to an annoying warning:
```json
{"time":"2024-11-11T08:49:24.431844605Z","level":"WARN","msg":"failed to parse reverse proxy ip ranges"}
```

My fix is super simple, I decided to move it into the loop to also skip empty IPs within commas, for example when joining multiple IPs (like `10.x.x.x,,192.x.x.x`).