### PR TITLE
Update smtp_pass environment variable in compose.yml

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -37,7 +37,7 @@ secrets:
   password_salt:
     environment: WAKAPI_PASSWORD_SALT
   smtp_pass:
-    environment: WAKAPI_SMTP_PASS
+    environment: WAKAPI_MAIL_SMTP_PASS
   db_password:
     environment: WAKAPI_DB_PASSWORD
 


### PR DESCRIPTION
According to [`compose.yml`](https://github.com/muety/wakapi/blob/4f1b2d0a711c67ad7eb247308be61f3e6b96894f/compose.yml#L40) line 40, the appropriate environment variable to set the `smtp_pass` docker secret is `WAKAPI_SMTP_PASS`, not `WAKAPI_MAIL_SMTP_PASS`. I presume it's the README that needs to be changed, not the compose file itself - if `WAKAPI_MAIL_SMTP_PASS` is instead the desired environment variable name, let me know and I can update the PR accordingly.