### PR TITLE
Docker: docker/build-push-action@v6, remove workflow_dispatch

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,7 +1,6 @@
 name: Publish Docker Image
 
 on:
-  workflow_dispatch:
   release:
     types:
       - published
@@ -54,7 +53,7 @@ jobs:
             type=semver,pattern={{version}}
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: Dockerfile


### PR DESCRIPTION
- Bump docker/build-push-action@v6
- Remove `workflow_dispatch` to prevent accidental manual trigger of pipeline (such as my mistake* in https://github.com/muety/wakapi/actions/runs/13284065152).  

Tested: https://github.com/YC/wakapi/actions/runs/13284149953

\* This should have been run against my fork. Thankfully, I caught and cancelled it before it pushed anything. 
Wanted to make a note of this in case anyone is wondering why that happened. 