### PR TITLE
Add .env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ node_modules
 .DS_Store
 .venv
 venv
+.env


### PR DESCRIPTION
I'm using a `.env` file to pass secrets to Docker Compose, and it would be nice if the file was ignored by git.