### PR TITLE
feat(api): return health check as JSON

### DIFF
--- a/routes/api/health.go
+++ b/routes/api/health.go
@@ -1,7 +1,7 @@
 package api
 
 import (
-	"fmt"
+	"encoding/json"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
@@ -10,6 +10,11 @@ import (
 
 type HealthApiHandler struct {
 	db *gorm.DB
+}
+
+type HealthResponse struct {
+	App int `json:"app"`
+	DB  int `json:"db"`
 }
 
 func NewHealthApiHandler(db *gorm.DB) *HealthApiHandler {
@@ -23,17 +28,18 @@ func (h *HealthApiHandler) RegisterRoutes(router chi.Router) {
 // @Summary Check the application's health status
 // @ID get-health
 // @Tags misc
-// @Produce plain
-// @Success 200 {string} string
+// @Produce json
+// @Success 200 {object} map[string]int
 // @Router /health [get]
 func (h *HealthApiHandler) Get(w http.ResponseWriter, r *http.Request) {
-	var dbStatus int
+	response := HealthResponse{App: 1, DB: 0}
+
 	if sqlDb, err := h.db.DB(); err == nil {
 		if err := sqlDb.Ping(); err == nil {
-			dbStatus = 1
+			response.DB = 1
 		}
 	}
 
-	w.Header().Set("Content-Type", "text/plain")
-	w.Write([]byte(fmt.Sprintf("app=1\ndb=%d", dbStatus)))
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(response)
 }


### PR DESCRIPTION
Updated the `/health` endpoint to return a JSON response (`{"app": 1, "db": 1}`) instead of plain text.

With a structured JSON response, it will help users to monitor the wakapi health with ease. Like recently using uptime-kuma, I faced difficulty in creating the monitoring rule for wakapi due to the plain text with a `\n`.