### PR TITLE
feat: add user preference for start of week

### DIFF
--- a/helpers/interval.go
+++ b/helpers/interval.go
@@ -2,9 +2,10 @@ package helpers
 
 import (
 	"errors"
+	"time"
+
 	"github.com/muety/wakapi/models"
 	"github.com/muety/wakapi/utils"
-	"time"
 )
 
 func ParseInterval(interval string) (*models.IntervalKey, error) {
@@ -21,20 +22,20 @@ func MustParseInterval(interval string) *models.IntervalKey {
 	return key
 }
 
-func MustResolveIntervalRawTZ(interval string, tz *time.Location) (from, to time.Time) {
-	_, from, to = ResolveIntervalRawTZ(interval, tz)
+func MustResolveIntervalRawTZ(interval string, tz *time.Location, startOfWeek time.Weekday) (from, to time.Time) {
+	_, from, to = ResolveIntervalRawTZ(interval, tz, startOfWeek)
 	return from, to
 }
 
-func ResolveIntervalRawTZ(interval string, tz *time.Location) (err error, from, to time.Time) {
+func ResolveIntervalRawTZ(interval string, tz *time.Location, startOfWeek time.Weekday) (err error, from, to time.Time) {
 	parsed, err := ParseInterval(interval)
 	if err != nil {
 		return err, time.Time{}, time.Time{}
 	}
-	return ResolveIntervalTZ(parsed, tz)
+	return ResolveIntervalTZ(parsed, tz, startOfWeek)
 }
 
-func ResolveIntervalTZ(interval *models.IntervalKey, tz *time.Location) (err error, from, to time.Time) {
+func ResolveIntervalTZ(interval *models.IntervalKey, tz *time.Location, startOfWeek time.Weekday) (err error, from, to time.Time) {
 	now := time.Now().In(tz)
 	to = now
 
@@ -47,10 +48,10 @@ func ResolveIntervalTZ(interval *models.IntervalKey, tz *time.Location) (err err
 	case models.IntervalPastDay:
 		from = now.Add(-24 * time.Hour)
 	case models.IntervalThisWeek:
-		from = utils.BeginOfThisWeek(tz)
+		from = utils.BeginOfThisWeek(tz, startOfWeek)
 	case models.IntervalLastWeek:
-		from = utils.BeginOfThisWeek(tz).AddDate(0, 0, -7)
-		to = utils.BeginOfThisWeek(tz)
+		from = utils.BeginOfThisWeek(tz, startOfWeek).AddDate(0, 0, -7)
+		to = utils.BeginOfThisWeek(tz, startOfWeek)
 	case models.IntervalThisMonth:
 		from = utils.BeginOfThisMonth(tz)
 	case models.IntervalLastMonth:

--- a/helpers/interval_test.go
+++ b/helpers/interval_test.go
@@ -1,16 +1,17 @@
 package helpers
 
 import (
-	"github.com/muety/wakapi/models"
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	"github.com/muety/wakapi/models"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestResolveMaximumRange_Default(t *testing.T) {
 	for i := 1; i <= 367; i++ {
 		err1, maximumInterval := ResolveMaximumRange(i)
-		err2, from, to := ResolveIntervalTZ(maximumInterval, time.UTC)
+		err2, from, to := ResolveIntervalTZ(maximumInterval, time.UTC, time.Monday)
 
 		assert.Nil(t, err1)
 		assert.Nil(t, err2)

--- a/helpers/summary.go
+++ b/helpers/summary.go
@@ -2,9 +2,10 @@ package helpers
 
 import (
 	"errors"
-	"github.com/muety/wakapi/models"
 	"net/http"
 	"time"
+
+	"github.com/muety/wakapi/models"
 )
 
 func ParseSummaryParams(r *http.Request) (*models.SummaryParams, error) {
@@ -15,9 +16,9 @@ func ParseSummaryParams(r *http.Request) (*models.SummaryParams, error) {
 	var from, to time.Time
 
 	if interval := params.Get("interval"); interval != "" {
-		err, from, to = ResolveIntervalRawTZ(interval, user.TZ())
+		err, from, to = ResolveIntervalRawTZ(interval, user.TZ(), user.StartOfWeekDay())
 	} else if start := params.Get("start"); start != "" {
-		err, from, to = ResolveIntervalRawTZ(start, user.TZ())
+		err, from, to = ResolveIntervalRawTZ(start, user.TZ(), user.StartOfWeekDay())
 	} else {
 		from, err = ParseDateTimeTZ(params.Get("from"), user.TZ())
 		if err != nil {

--- a/migrations/20250818_add_start_of_week.go
+++ b/migrations/20250818_add_start_of_week.go
@@ -1,0 +1,41 @@
+package migrations
+
+import (
+	"github.com/muety/wakapi/config"
+	"gorm.io/gorm"
+)
+
+func init() {
+	const name = "20250818-add_start-of-week"
+	f := migrationFunc{
+		name:       name,
+		background: true,
+		f: func(db *gorm.DB, cfg *config.Config) error {
+			if hasRun(name, db) {
+				return nil
+			}
+
+			// Check if column already exists
+			var count int64
+			if err := db.Raw("SELECT COUNT(*) FROM pragma_table_info('users') WHERE name = 'start_of_week'").Scan(&count).Error; err != nil {
+				// If pragma_table_info fails (e.g., MySQL/PostgreSQL), try a different approach
+				if err := db.Raw("SELECT COUNT(*) FROM information_schema.columns WHERE table_name = 'users' AND column_name = 'start_of_week'").Scan(&count).Error; err != nil {
+					// If that also fails, assume column doesn't exist and proceed
+					count = 0
+				}
+			}
+
+			// Only add column if it doesn't exist
+			if count == 0 {
+				if err := db.Exec("ALTER TABLE users ADD COLUMN start_of_week INTEGER DEFAULT 1").Error; err != nil {
+					return err
+				}
+			}
+
+			setHasRun(name, db)
+			return nil
+		},
+	}
+
+	registerPostMigration(f)
+}

--- a/models/user.go
+++ b/models/user.go
@@ -28,6 +28,7 @@ type User struct {
 	ApiKey                 string      `json:"api_key" gorm:"unique; default:NULL"`
 	Email                  string      `json:"email" gorm:"index:idx_user_email; size:255"`
 	Location               string      `json:"location"`
+	StartOfWeek            int         `json:"start_of_week" gorm:"default:1"`
 	Password               string      `json:"-"`
 	CreatedAt              CustomTime  `swaggertype:"string" format:"date" example:"2006-01-02 15:04:05.000"` // filled by gorm, see https://gorm.io/docs/conventions.html#CreatedAt
 	LastLoggedInAt         CustomTime  `swaggertype:"string" format:"date" example:"2006-01-02 15:04:05.000"` // filled by gorm, see https://gorm.io/docs/conventions.html#CreatedAt
@@ -90,6 +91,7 @@ type CredentialsReset struct {
 type UserDataUpdate struct {
 	Email             string `schema:"email"`
 	Location          string `schema:"location"`
+	StartOfWeek       int    `schema:"start_of_week"`
 	ReportsWeekly     bool   `schema:"reports_weekly"`
 	PublicLeaderboard bool   `schema:"public_leaderboard"`
 }
@@ -124,6 +126,14 @@ func (u *User) TZ() *time.Location {
 func (u *User) TZOffset() time.Duration {
 	_, offset := time.Now().In(u.TZ()).Zone()
 	return time.Duration(offset * int(time.Second))
+}
+
+// StartOfWeekDay returns the user's preferred start of week as time.Weekday
+func (u *User) StartOfWeekDay() time.Weekday {
+	if u.StartOfWeek < 0 || u.StartOfWeek > 6 {
+		u.StartOfWeek = 1 // Default to Monday
+	}
+	return time.Weekday(u.StartOfWeek)
 }
 
 func (u *User) AvatarURL(urlTemplate string) string {
@@ -215,7 +225,7 @@ func (s *Signup) IsValid() bool {
 }
 
 func (r *UserDataUpdate) IsValid() bool {
-	return ValidateEmail(r.Email) && ValidateTimezone(r.Location)
+	return ValidateEmail(r.Email) && ValidateTimezone(r.Location) && ValidateStartOfWeek(r.StartOfWeek)
 }
 
 func ValidateUsername(username string) bool {
@@ -240,4 +250,8 @@ func ValidateEmail(email string) bool {
 func ValidateTimezone(tz string) bool {
 	_, err := time.LoadLocation(tz)
 	return err == nil
+}
+
+func ValidateStartOfWeek(startOfWeek int) bool {
+	return startOfWeek >= 0 && startOfWeek <= 6
 }

--- a/repositories/user.go
+++ b/repositories/user.go
@@ -3,8 +3,9 @@ package repositories
 import (
 	"errors"
 	"fmt"
-	"github.com/duke-git/lancet/v2/condition"
 	"time"
+
+	"github.com/duke-git/lancet/v2/condition"
 
 	"github.com/muety/wakapi/models"
 	"github.com/muety/wakapi/utils"
@@ -144,6 +145,7 @@ func (r *UserRepository) Update(user *models.User) (*models.User, error) {
 		"has_data":                 user.HasData,
 		"reset_token":              user.ResetToken,
 		"location":                 user.Location,
+		"start_of_week":            user.StartOfWeek,
 		"reports_weekly":           user.ReportsWeekly,
 		"public_leaderboard":       user.PublicLeaderboard,
 		"subscribed_until":         user.SubscribedUntil,

--- a/routes/api/metrics.go
+++ b/routes/api/metrics.go
@@ -2,6 +2,13 @@ package api
 
 import (
 	"errors"
+	"log/slog"
+	"net/http"
+	"runtime"
+	"sort"
+	"sync"
+	"time"
+
 	"github.com/alitto/pond/v2"
 	"github.com/go-chi/chi/v5"
 	conf "github.com/muety/wakapi/config"
@@ -13,12 +20,6 @@ import (
 	"github.com/muety/wakapi/repositories"
 	"github.com/muety/wakapi/services"
 	"github.com/muety/wakapi/utils"
-	"log/slog"
-	"net/http"
-	"runtime"
-	"sort"
-	"sync"
-	"time"
 )
 
 const (
@@ -145,7 +146,7 @@ func (h *MetricsHandler) getUserMetrics(user *models.User) (*mm.Metrics, error) 
 		return nil, err
 	}
 
-	from, to := helpers.MustResolveIntervalRawTZ("today", user.TZ())
+	from, to := helpers.MustResolveIntervalRawTZ("today", user.TZ(), user.StartOfWeekDay())
 
 	summaryToday, err := h.summarySrvc.Aliased(from, to, user, h.summarySrvc.Retrieve, nil, nil, false)
 	if err != nil {
@@ -455,7 +456,7 @@ func (h *MetricsHandler) getAdminMetrics(user *models.User) (*mm.Metrics, error)
 
 	// Get per-user total activity
 
-	_, from, to := helpers.ResolveIntervalTZ(models.IntervalAny, time.Local)
+	_, from, to := helpers.ResolveIntervalTZ(models.IntervalAny, time.Local, time.Monday)
 	to = to.Truncate(time.Hour)
 
 	wp := pond.NewPool(utils.HalfCPUs())

--- a/routes/compat/shields/v1/badge.go
+++ b/routes/compat/shields/v1/badge.go
@@ -2,12 +2,13 @@ package v1
 
 import (
 	"fmt"
+	"net/http"
+	"time"
+
 	"github.com/go-chi/chi/v5"
 	"github.com/muety/wakapi/helpers"
 	"github.com/muety/wakapi/models/types"
 	routeutils "github.com/muety/wakapi/routes/utils"
-	"net/http"
-	"time"
 
 	conf "github.com/muety/wakapi/config"
 	"github.com/muety/wakapi/models"
@@ -88,7 +89,7 @@ func (h *BadgeHandler) Get(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *BadgeHandler) loadUserSummary(user *models.User, interval *models.IntervalKey, filters *models.Filters) (*models.Summary, error, int) {
-	err, from, to := helpers.ResolveIntervalTZ(interval, user.TZ())
+	err, from, to := helpers.ResolveIntervalTZ(interval, user.TZ(), user.StartOfWeekDay())
 	if err != nil {
 		return nil, err, http.StatusBadRequest
 	}

--- a/routes/compat/wakatime/v1/leaders.go
+++ b/routes/compat/wakatime/v1/leaders.go
@@ -1,16 +1,17 @@
 package v1
 
 import (
+	"math"
+	"net/http"
+	"strings"
+	"time"
+
 	"github.com/duke-git/lancet/v2/slice"
 	"github.com/go-chi/chi/v5"
 	"github.com/muety/wakapi/helpers"
 	"github.com/muety/wakapi/middlewares"
 	"github.com/muety/wakapi/models"
 	"github.com/muety/wakapi/utils"
-	"math"
-	"net/http"
-	"strings"
-	"time"
 
 	conf "github.com/muety/wakapi/config"
 	v1 "github.com/muety/wakapi/models/compat/wakatime/v1"
@@ -120,7 +121,7 @@ func (h *LeadersHandler) buildViewModel(globalLeaderboard, languageLeaderboard m
 	totalUsers, _ := h.leaderboardSrvc.CountUsers(true)
 	totalPages := int(totalUsers/int64(pageParams.PageSize) + 1)
 
-	_, from, to := helpers.ResolveIntervalTZ(interval, time.UTC)
+	_, from, to := helpers.ResolveIntervalTZ(interval, time.UTC, time.Monday)
 	numDays := len(utils.SplitRangeByDays(from, to))
 
 	vm := &v1.LeadersViewModel{

--- a/routes/compat/wakatime/v1/stats.go
+++ b/routes/compat/wakatime/v1/stats.go
@@ -87,7 +87,7 @@ func (h *StatsHandler) Get(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	err, rangeFrom, rangeTo := helpers.ResolveIntervalRawTZ(rangeParam, requestedUser.TZ())
+	err, rangeFrom, rangeTo := helpers.ResolveIntervalRawTZ(rangeParam, requestedUser.TZ(), requestedUser.StartOfWeekDay())
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte("invalid range"))

--- a/routes/compat/wakatime/v1/statusbar.go
+++ b/routes/compat/wakatime/v1/statusbar.go
@@ -1,11 +1,12 @@
 package v1
 
 import (
+	"net/http"
+	"time"
+
 	"github.com/go-chi/chi/v5"
 	"github.com/muety/wakapi/helpers"
 	"github.com/muety/wakapi/models/types"
-	"net/http"
-	"time"
 
 	conf "github.com/muety/wakapi/config"
 	"github.com/muety/wakapi/middlewares"
@@ -63,7 +64,7 @@ func (h *StatusBarHandler) Get(w http.ResponseWriter, r *http.Request) {
 		rangeParam = (*models.IntervalToday)[0]
 	}
 
-	err, rangeFrom, rangeTo := helpers.ResolveIntervalRawTZ(rangeParam, user.TZ())
+	err, rangeFrom, rangeTo := helpers.ResolveIntervalRawTZ(rangeParam, user.TZ(), user.StartOfWeekDay())
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte("invalid range"))

--- a/routes/compat/wakatime/v1/summaries.go
+++ b/routes/compat/wakatime/v1/summaries.go
@@ -2,12 +2,13 @@ package v1
 
 import (
 	"errors"
-	"github.com/duke-git/lancet/v2/datetime"
-	"github.com/go-chi/chi/v5"
-	"github.com/muety/wakapi/helpers"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/duke-git/lancet/v2/datetime"
+	"github.com/go-chi/chi/v5"
+	"github.com/muety/wakapi/helpers"
 
 	conf "github.com/muety/wakapi/config"
 	"github.com/muety/wakapi/middlewares"
@@ -84,6 +85,7 @@ func (h *SummariesHandler) loadUserSummaries(r *http.Request, user *models.User)
 	rangeParam, startParam, endParam, tzParam := params.Get("range"), params.Get("start"), params.Get("end"), params.Get("timezone")
 
 	timezone := user.TZ()
+	startOfWeek := user.StartOfWeekDay()
 	if tzParam != "" {
 		if tz, err := time.LoadLocation(tzParam); err == nil {
 			timezone = tz
@@ -93,12 +95,12 @@ func (h *SummariesHandler) loadUserSummaries(r *http.Request, user *models.User)
 	var start, end time.Time
 	if rangeParam != "" {
 		// range param takes precedence
-		if err, parsedFrom, parsedTo := helpers.ResolveIntervalRawTZ(rangeParam, timezone); err == nil {
+		if err, parsedFrom, parsedTo := helpers.ResolveIntervalRawTZ(rangeParam, timezone, startOfWeek); err == nil {
 			start, end = parsedFrom, parsedTo
 		} else {
 			return nil, errors.New("invalid 'range' parameter"), http.StatusBadRequest
 		}
-	} else if err, parsedFrom, parsedTo := helpers.ResolveIntervalRawTZ(startParam, timezone); err == nil && startParam == endParam {
+	} else if err, parsedFrom, parsedTo := helpers.ResolveIntervalRawTZ(startParam, timezone, startOfWeek); err == nil && startParam == endParam {
 		// also accept start param to be a range param
 		start, end = parsedFrom, parsedTo
 	} else {

--- a/routes/settings.go
+++ b/routes/settings.go
@@ -3,16 +3,19 @@ package routes
 import (
 	"encoding/base64"
 	"fmt"
-	"github.com/duke-git/lancet/v2/condition"
-	"github.com/go-chi/chi/v5"
-	"github.com/gofrs/uuid/v5"
-	"github.com/muety/wakapi/helpers"
 	"net/http"
 	"net/url"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/duke-git/lancet/v2/condition"
+	"github.com/go-chi/chi/v5"
+	"github.com/gofrs/uuid/v5"
+	"github.com/muety/wakapi/helpers"
+
+	"log/slog"
 
 	datastructure "github.com/duke-git/lancet/v2/datastructure/set"
 	"github.com/gorilla/schema"
@@ -24,7 +27,6 @@ import (
 	"github.com/muety/wakapi/services"
 	"github.com/muety/wakapi/services/imports"
 	"github.com/muety/wakapi/utils"
-	"log/slog"
 )
 
 const criticalError = "a critical error has occurred, sorry"
@@ -220,6 +222,7 @@ func (h *SettingsHandler) actionUpdateUser(w http.ResponseWriter, r *http.Reques
 
 	user.Email = payload.Email
 	user.Location = payload.Location
+	user.StartOfWeek = payload.StartOfWeek
 	user.ReportsWeekly = payload.ReportsWeekly
 	user.PublicLeaderboard = payload.PublicLeaderboard
 

--- a/routes/utils/badge_utils.go
+++ b/routes/utils/badge_utils.go
@@ -2,9 +2,10 @@ package utils
 
 import (
 	"errors"
+	"regexp"
+
 	"github.com/muety/wakapi/helpers"
 	"github.com/muety/wakapi/models"
-	"regexp"
 )
 
 const (
@@ -37,7 +38,7 @@ func GetBadgeParams(reqPath string, authorizedUser, requestedUser *models.User) 
 		}
 	}
 
-	_, rangeFrom, rangeTo := helpers.ResolveIntervalTZ(intervalKey, requestedUser.TZ())
+	_, rangeFrom, rangeTo := helpers.ResolveIntervalTZ(intervalKey, requestedUser.TZ(), requestedUser.StartOfWeekDay())
 	interval := &models.KeyedInterval{
 		Interval: models.Interval{Start: rangeFrom, End: rangeTo},
 		Key:      intervalKey,

--- a/services/activity.go
+++ b/services/activity.go
@@ -5,6 +5,10 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
+	"math"
+	"sync"
+	"time"
+
 	svg "github.com/ajstarks/svgo/float"
 	"github.com/alitto/pond/v2"
 	"github.com/duke-git/lancet/v2/condition"
@@ -14,9 +18,6 @@ import (
 	"github.com/muety/wakapi/models"
 	"github.com/muety/wakapi/utils"
 	"github.com/patrickmn/go-cache"
-	"math"
-	"sync"
-	"time"
 )
 
 const (
@@ -67,7 +68,8 @@ func (s *ActivityService) GetChart(user *models.User, interval *models.IntervalK
 }
 
 func (s *ActivityService) getChartPastYear(user *models.User, darkTheme, hideAttribution bool) (string, error) {
-	err, from, to := helpers.ResolveIntervalTZ(models.IntervalPast12Months, user.TZ())
+	err, from, to := helpers.ResolveIntervalTZ(models.IntervalPast12Months, user.TZ(), user.StartOfWeekDay())
+	// TODO: I am not sure if we have to handle startOfWeekDay here, but it seems like we do not need to.
 	from = datetime.BeginOfWeek(from, time.Monday)
 	if err != nil {
 		return "", err

--- a/services/leaderboard.go
+++ b/services/leaderboard.go
@@ -2,6 +2,12 @@ package services
 
 import (
 	"fmt"
+	"log/slog"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/leandro-lugaresi/hub"
 	"github.com/muety/artifex/v2"
 	"github.com/muety/wakapi/config"
@@ -10,11 +16,6 @@ import (
 	"github.com/muety/wakapi/repositories"
 	"github.com/muety/wakapi/utils"
 	"github.com/patrickmn/go-cache"
-	"log/slog"
-	"reflect"
-	"strconv"
-	"strings"
-	"time"
 )
 
 type LeaderboardService struct {
@@ -225,7 +226,7 @@ func (srv *LeaderboardService) GetAggregatedByIntervalAndUser(interval *models.I
 }
 
 func (srv *LeaderboardService) GenerateByUser(user *models.User, interval *models.IntervalKey) (*models.LeaderboardItem, error) {
-	err, from, to := helpers.ResolveIntervalTZ(interval, user.TZ())
+	err, from, to := helpers.ResolveIntervalTZ(interval, user.TZ(), user.StartOfWeekDay())
 	if err != nil {
 		return nil, err
 	}
@@ -247,7 +248,7 @@ func (srv *LeaderboardService) GenerateByUser(user *models.User, interval *model
 }
 
 func (srv *LeaderboardService) GenerateAggregatedByUser(user *models.User, interval *models.IntervalKey, by uint8) ([]*models.LeaderboardItem, error) {
-	err, from, to := helpers.ResolveIntervalTZ(interval, user.TZ())
+	err, from, to := helpers.ResolveIntervalTZ(interval, user.TZ(), user.StartOfWeekDay())
 	if err != nil {
 		return nil, err
 	}

--- a/utils/date.go
+++ b/utils/date.go
@@ -1,9 +1,10 @@
 package utils
 
 import (
-	"github.com/duke-git/lancet/v2/datetime"
 	"strings"
 	"time"
+
+	"github.com/duke-git/lancet/v2/datetime"
 )
 
 func MustParseTime(layout, value string) time.Time {
@@ -15,8 +16,8 @@ func BeginOfToday(tz *time.Location) time.Time {
 	return datetime.BeginOfDay(time.Now().In(tz))
 }
 
-func BeginOfThisWeek(tz *time.Location) time.Time {
-	return datetime.BeginOfWeek(time.Now().In(tz), time.Monday)
+func BeginOfThisWeek(tz *time.Location, startOfWeek time.Weekday) time.Time {
+	return datetime.BeginOfWeek(time.Now().In(tz), startOfWeek)
 }
 
 func BeginOfThisMonth(tz *time.Location) time.Time {

--- a/views/settings.tpl.html
+++ b/views/settings.tpl.html
@@ -78,6 +78,24 @@
 
                 <div class="flex mb-8">
                     <div class="w-1/2 mr-4 inline-block">
+                        <label class="font-semibold text-gray-300" for="select-start-of-week">Start of Week</label>
+                        <span class="block text-sm text-gray-600">Choose which day your week starts on. This affects "This Week" and "Last Week" intervals.</span>
+                    </div>
+                    <div class="w-1/2 ml-4">
+                        <select name="start_of_week" id="select-start-of-week" class="select-default">
+                            <option value="0" {{ if eq .User.StartOfWeek 0 }}selected{{ end }}>Sunday</option>
+                            <option value="1" {{ if eq .User.StartOfWeek 1 }}selected{{ end }}>Monday</option>
+                            <option value="2" {{ if eq .User.StartOfWeek 2 }}selected{{ end }}>Tuesday</option>
+                            <option value="3" {{ if eq .User.StartOfWeek 3 }}selected{{ end }}>Wednesday</option>
+                            <option value="4" {{ if eq .User.StartOfWeek 4 }}selected{{ end }}>Thursday</option>
+                            <option value="5" {{ if eq .User.StartOfWeek 5 }}selected{{ end }}>Friday</option>
+                            <option value="6" {{ if eq .User.StartOfWeek 6 }}selected{{ end }}>Saturday</option>
+                        </select>
+                    </div>
+                </div>
+
+                <div class="flex mb-8">
+                    <div class="w-1/2 mr-4 inline-block">
                         <label class="font-semibold text-gray-300" for="email">E-Mail Address</label>
                         <span class="block text-sm text-gray-600">
                             Optional in general, but required for weekly reports and for resetting your password.


### PR DESCRIPTION
In the original WakaTime, there is an option to set the start of the week, but that option is missing here.

<img width="792" height="835" alt="1755531088068" src="https://github.com/user-attachments/assets/7df62b9d-76f7-4974-b5cf-490ff940fe68" />
<img width="1920" height="911" alt="1755531250006" src="https://github.com/user-attachments/assets/73b907a7-2b1f-4549-bbd6-beffd5b7a088" />
<img width="1920" height="911" alt="1755531308683" src="https://github.com/user-attachments/assets/d578d26d-2488-49fa-b8c3-80c30e46cbf8" />

---

## This PR implements the feature to customize the start of the week
<img width="1920" height="945" alt="image" src="https://github.com/user-attachments/assets/8713deb5-f8f5-416d-906c-15edb07cd420" />
<img width="1920" height="945" alt="image" src="https://github.com/user-attachments/assets/678f4992-e7fa-4423-9a27-1000370b2f64" />

