### PR TITLE
fix: show all available filter options while filtering is active (close #695)

### DIFF
--- a/models/view/summary.go
+++ b/models/view/summary.go
@@ -12,6 +12,7 @@ type SummaryViewModel struct {
 	SharedLoggedInViewModel
 	*models.Summary
 	*models.SummaryParams
+	AvailableFilters    AvailableFilters
 	AvatarURL           string
 	EditorColors        map[string]string
 	LanguageColors      map[string]string
@@ -22,6 +23,14 @@ type SummaryViewModel struct {
 	RawQuery            string
 	UserFirstData       time.Time
 	DataRetentionMonths int
+}
+
+type AvailableFilters struct {
+	ProjectNames  []string
+	LanguageNames []string
+	MachineNames  []string
+	LabelNames    []string
+	CategoryNames []string
 }
 
 type TimelineViewModel struct {

--- a/views/summary.tpl.html
+++ b/views/summary.tpl.html
@@ -34,31 +34,31 @@
         <div class="flex-grow flex-shrink hidden md:flex justify-start gap-x-4 flex-wrap">
             <div v-scope="EntityFilter({
                 type: 'project',
-                options: wakapiData.projects.map(p => p.key).toSorted(),
+                options: wakapiData.availableProjectNames.toSorted(),
                 selection: null,
             })" @vue:mounted="mounted"></div>
 
             <div v-scope="EntityFilter({
                 type: 'language',
-                options: wakapiData.languages.map(p => p.key).toSorted(),
+                options: wakapiData.availableLanguageNames.toSorted(),
                 selection: null,
             })" @vue:mounted="mounted"></div>
 
             <div v-scope="EntityFilter({
                 type: 'machine',
-                options: wakapiData.machines.map(p => p.key).toSorted(),
+                options: wakapiData.availableMachineNames.toSorted(),
                 selection: null,
             })" @vue:mounted="mounted"></div>
 
             <div v-scope="EntityFilter({
                 type: 'label',
-                options: wakapiData.labels.map(p => p.key).toSorted(),
+                options: wakapiData.availableLabelNames.toSorted(),
                 selection: null,
             })" @vue:mounted="mounted"></div>
 
             <div v-scope="EntityFilter({
                 type: 'category',
-                options: wakapiData.categories.map(p => p.key).toSorted(),
+                options: wakapiData.availableCategoryNames.toSorted(),
                 selection: null,
             })" @vue:mounted="mounted"></div>
         </div>
@@ -399,6 +399,11 @@
     wakapiData.hourlyBreakdown = {{ .HourlyBreakdown | json }}
     wakapiData.hourlyBreakdownFromTime = {{ .HourlyBreakdownFrom | json }}
     wakapiData.hourlyBreakdownToTime = {{ .SummaryParams.To | json }}
+    wakapiData.availableProjectNames = {{ .AvailableFilters.ProjectNames | json }}
+    wakapiData.availableLanguageNames = {{ .AvailableFilters.LanguageNames | json }}
+    wakapiData.availableMachineNames = {{ .AvailableFilters.MachineNames | json }}
+    wakapiData.availableLabelNames = {{ .AvailableFilters.LabelNames | json }}
+    wakapiData.availableCategoryNames = {{ .AvailableFilters.CategoryNames | json }}
     {{ if .IsProjectDetails }}
     wakapiData.branches = {{ .Branches | json }}
     wakapiData.entities = {{ .Entities | json }}


### PR DESCRIPTION
I done this by retrieving a summary of the same period without any filters. Maybe there's a more efficient way that I didn't come up with.