### PR TITLE
feat: add custom Readme Stats base URL functionality

### DIFF
--- a/models/user.go
+++ b/models/user.go
@@ -55,6 +55,7 @@ type User struct {
 	InvitedBy              string      `json:"-"`
 	ExcludeUnknownProjects bool        `json:"-"`
 	HeartbeatsTimeoutSec   int         `json:"-" gorm:"default:600"` // https://github.com/muety/wakapi/issues/156
+	ReadmeStatsBaseUrl     string      `json:"-" gorm:"default:''"`
 	AuthType               string      `json:"auth_type" gorm:"default:local; size:255"`
 	Sub                    string      `json:"sub" gorm:"size:255"` // openid connect subject
 }

--- a/repositories/user.go
+++ b/repositories/user.go
@@ -163,6 +163,7 @@ func (r *UserRepository) Update(user *models.User) (*models.User, error) {
 		"invited_by":               user.InvitedBy,
 		"exclude_unknown_projects": user.ExcludeUnknownProjects,
 		"heartbeats_timeout_sec":   user.HeartbeatsTimeoutSec,
+		"readme_stats_base_url":    user.ReadmeStatsBaseUrl,
 	}
 
 	result := r.db.Model(user).Updates(updateMap)

--- a/views/settings.tpl.html
+++ b/views/settings.tpl.html
@@ -822,13 +822,24 @@
                     <div class="w-full md:w-1/2">
                         {{ if ne .User.ShareDataMaxDays 0 }}
                         <div class="flex items-center mb-2">
-                            <img src="https://github-readme-stats.vercel.app/api/wakatime?username={{ .User.ID }}&api_domain=%s&bg_color=1A202C&title_color=2F855A&icon_color=2F855A&text_color=ffffff&custom_title={{ .ReadmeCardCustomTitle }}&layout=compact"
+                            <img src="{{ if .User.ReadmeStatsBaseUrl }}{{ .User.ReadmeStatsBaseUrl }}{{ else }}https://github-readme-stats.vercel.app{{ end }}/api/wakatime?username={{ .User.ID }}&api_domain=%s&bg_color=1A202C&title_color=2F855A&icon_color=2F855A&text_color=ffffff&custom_title={{ .ReadmeCardCustomTitle }}&layout=compact"
                                  class="with-url-src-no-scheme" alt="Readme Stats Card">
                         </div>
                         <textarea
                                 class="with-url-inner-no-scheme shrink w-full font-mono text-xs appearance-none bg-card text-secondary outline-none rounded py-2 px-4 cursor-not-allowed mt-2"
                                 rows="5" style="resize: none"
-                                readonly>https://github-readme-stats.vercel.app/api/wakatime?username={{ .User.ID }}&api_domain=%s&bg_color=1A202C&title_color=2F855A&icon_color=2F855A&text_color=ffffff&custom_title={{ .ReadmeCardCustomTitle }}&layout=compact</textarea>
+                                readonly>{{ if .User.ReadmeStatsBaseUrl }}{{ .User.ReadmeStatsBaseUrl }}{{ else }}https://github-readme-stats.vercel.app{{ end }}/api/wakatime?username={{ .User.ID }}&api_domain=%s&bg_color=1A202C&title_color=2F855A&icon_color=2F855A&text_color=ffffff&custom_title={{ .ReadmeCardCustomTitle | urlquery }}&layout=compact</textarea>
+
+                        <form class="w-full mt-4" action="" method="post">
+                            <input type="hidden" name="action" value="update_readme_stats_base_url">
+                            <div class="flex flex-col flex-grow gap-y-1">
+                                <label class="font-semibold text-foreground text-sm" for="readme_stats_base_url">Custom Readme Stats Base URL</label>
+                                <input class="input-default w-full text-sm" type="url" id="readme_stats_base_url" name="readme_stats_base_url" placeholder="https://github-readme-stats.vercel.app" value="{{ .User.ReadmeStatsBaseUrl }}">
+                            </div>
+                            <div class="flex justify-end mt-4">
+                                <button type="submit" class="btn-primary h-min py-2">Save</button>
+                            </div>
+                        </form>
                         {{ end }}
                     </div>
                 </div>


### PR DESCRIPTION
#889 

**Summary**
This PR adds a setting to configure a custom Base URL for `github-readme-stats`.

**Reason**
Enables users to use **self-hosted instances** instead of the public Vercel instance, solving potential rate-limiting or connectivity issues.

**Changes**

* **Model:** Added `ReadmeStatsBaseUrl` to the `User` struct.
* **UI:** Added a "Custom Base URL" input in the Settings page.
* **Logic:** The badge URL now uses the custom base URL if defined; otherwise, it defaults to `https://github-readme-stats.vercel.app`.

**Checklist**

* [x] Tested locally
* [x] Database model updated