### PR TITLE
fix: correct editor identification for wakatime-ls (#914)

### DIFF
--- a/utils/http.go
+++ b/utils/http.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+
 	"github.com/duke-git/lancet/v2/condition"
 	"github.com/duke-git/lancet/v2/strutil"
 	"github.com/mileusna/useragent"
@@ -20,6 +21,11 @@ const (
 	userAgentPattern   = `(?iU)^(?:(?:wakatime|chrome|firefox|edge)\/(?:v?[\d+.]+|unset)?\s)(?:\(?(\w+)[-_].*\)?.+\s)?(?:([^\/\s]+)\/[\w\d\.]+\s)?([^\/\s]+)-wakatime\/.+$`
 	cacheMaxAgePattern = `max-age=(\d+)`
 )
+
+var editorMiddlewares = map[string]bool{
+	"wakatime-ls":  true,
+	"wakatime-cli": true,
+}
 
 var (
 	userAgentRe   *regexp.Regexp
@@ -112,7 +118,7 @@ func ParseUserAgent(ua string) (string, string, error) { // os, editor, err
 
 		// parse editor
 		editor = groups[0][2] // for user agents sent by desktop-wakatime plugin and some others, see https://github.com/muety/wakapi/issues/686, https://github.com/muety/wakapi/issues/712
-		if editor == "" {
+		if editor == "" || editorMiddlewares[strings.ToLower(editor)] {
 			editor = groups[0][3] // for most user agents
 		}
 		// special treatment for neovim

--- a/utils/http_test.go
+++ b/utils/http_test.go
@@ -1,0 +1,46 @@
+package utils
+
+import "testing"
+
+func TestParseUserAgent(t *testing.T) {
+	type args struct {
+		ua string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		want1   string
+		wantErr bool
+	}{
+		{
+			name:    "helix with wakatime-ls",
+			args:    struct{ ua string }{ua: "wakatime/1.139.1 (linux-6.18.8-unknown) go1.25.5 helix/25.07.1 (74075bb5) wakatime-ls/0.2.2 helix-wakatime/0.2.2"},
+			want:    "Linux",
+			want1:   "helix",
+			wantErr: false,
+		},
+		{
+			name:    "stardard vscode",
+			args:    struct{ ua string }{ua: "wakatime/v1.105.0 (linux-6.11.9-zen1-1-zen-unknown) go1.23.3 vscode/1.95.3 vscode-wakatime/24.8.0"},
+			want:    "Linux",
+			want1:   "vscode",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1, err := ParseUserAgent(tt.args.ua)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseUserAgent() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("ParseUserAgent() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("ParseUserAgent() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem
When the User-Agent string contains both a real editor (e.g. `helix`) and a middleware plugin (e.g. `wakatime-ls`), the middleware was incorrectly captured as the editor by capture group 2, causing group 3 (the actual editor) to be ignored.

Example UA:
`wakatime/1.139.1 (linux-6.18.8-unknown) go1.25.5 helix/25.07.1 (74075bb5) wakatime-ls/0.2.2 helix-wakatime/0.2.2`

## Solution
Introduce a middleware blocklist. When capture group 2 matches a known 
middleware, fall back to capture group 3 for the actual editor name.

Fixes #914