### PR TITLE
fix: remove unnecessary image layers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 FROM --platform=$BUILDPLATFORM golang:alpine AS build-env
 WORKDIR /src
 
-RUN apk add --no-cache ca-certificates tzdata && update-ca-certificates
-
 COPY ./go.mod ./go.sum ./
 RUN go mod download
 COPY . .
@@ -45,10 +43,7 @@ ENV ENVIRONMENT=prod \
     WAKAPI_INSECURE_COOKIES='true' \
     WAKAPI_ALLOW_SIGNUP='true'
 
-COPY --from=build-env --chown=nonroot:nonroot --chmod=0444 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY --from=build-env --chown=nonroot:nonroot --chmod=0555 /usr/share/zoneinfo /usr/share/zoneinfo
-
-COPY --from=build-env --chown=nonroot:nonroot /staging/app /app
+COPY --from=build-env --chown=root:root /staging/app /app
 COPY --from=build-env --chown=nonroot:nonroot /staging/data /data
 
 LABEL org.opencontainers.image.url="https://github.com/muety/wakapi" \


### PR DESCRIPTION
- Remove copy of `ca-certificates`, `zoneinfo` since the base image already has it
- Make the `/app` directory read only

### Testing
- [x] Can fetch `https://wakatime.com/`
- [x] Can determine time using timezone

```go
// Test code written with help from AI

// get https://wakatime.com
res, err := http.Get("https://wakatime.com")
if err != nil {
	conf.Log().Fatal(err.Error())
}
defer res.Body.Close()
body, err := io.ReadAll(res.Body)
if err != nil {
	conf.Log().Fatal(err.Error())
}
conf.Log().Info("Successfully fetched https://wakatime.com - your server can access the Wakatime API", "statusCode", res.StatusCode, "responseLength", len(body))

// check time location can be loaded
timeLocation, err := time.LoadLocation("America/New_York")
if err != nil {
	conf.Log().Fatal(err.Error())
}
conf.Log().Info("Successfully loaded time location", "location", timeLocation.String(), "currentTime", time.Now().In(timeLocation).String())
```

Output:
```
{"time":"2026-04-03T08:42:43.792487718Z","level":"INFO","msg":"Successfully fetched https://wakatime.com - your server can access the Wakatime API","statusCode":200,"responseLength":85446}
{"time":"2026-04-03T08:42:43.792915789Z","level":"INFO","msg":"Successfully loaded time location","location":"America/New_York","currentTime":"2026-04-03 04:42:43.792891408 -0400 EDT"}
```