### PR TITLE
fix(ui): show AI coding ratio without decimals

### DIFF
--- a/views/summary.tpl.html
+++ b/views/summary.tpl.html
@@ -100,7 +100,7 @@
             </div>
             <div class="flex flex-col w-full p-4 pt-2 rounded-md text-foreground bg-card leading-none border-2 border-accent">
                 <span class="text-xs text-muted font-semibold">AI coding ratio</span>
-                <span class="font-semibold text-xl truncate">{{ mulf64 (.Summary.CategoryRatio "ai coding" "ai coding" "coding") 100 }} %</span>
+                <span class="font-semibold text-xl truncate">{{ printf "%.0f" (mulf64 (.Summary.CategoryRatio "ai coding" "ai coding" "coding") 100) }} %</span>
             </div>
         </div>
 


### PR DESCRIPTION
The ai coding % could overflow and look a bit wierd. Removed decimal places

Before:
<img width="1342" height="134" alt="image" src="https://github.com/user-attachments/assets/c16d43a9-bd15-4ffa-ad3b-87d8ba86d7c4" />

After:
<img width="1342" height="134" alt="image" src="https://github.com/user-attachments/assets/dd16395f-26d9-4a8a-a91d-1ee9a7087d23" />
