### PR TITLE
feat(projects): persist selected interval when opening project stats

### DIFF
--- a/routes/summary.go
+++ b/routes/summary.go
@@ -61,10 +61,12 @@ func (h *SummaryHandler) GetIndex(w http.ResponseWriter, r *http.Request) {
 	rawQuery := r.URL.RawQuery
 	q := r.URL.Query()
 	if q.Get("interval") == "" && q.Get("from") == "" {
-		// If the PersistentIntervalKey cookie is set, redirect to the correct summary page
+		// If the PersistentIntervalKey cookie is set, redirect to the correct summary page,
+		// preserving any other query params (e.g. a project filter)
 		if intervalCookie, _ := r.Cookie(models.PersistentIntervalKey); intervalCookie != nil {
-			redirectAddress := fmt.Sprintf("%s/summary?interval=%s", h.config.Server.BasePath, intervalCookie.Value)
-			http.Redirect(w, r, redirectAddress, http.StatusFound)
+			q.Set("interval", intervalCookie.Value)
+			http.Redirect(w, r, fmt.Sprintf("%s/summary?%s", h.config.Server.BasePath, q.Encode()), http.StatusFound)
+			return
 		}
 
 		q.Set("interval", "today")

--- a/views/projects.tpl.html
+++ b/views/projects.tpl.html
@@ -32,7 +32,7 @@
             {{ range $i, $project := .Projects }}
             <li class="projects-item relative">
                 <div class="color-fading" style="{{ $.BackgroundIntensity $i | cssSafe }}"></div>
-                <a href="summary?interval=any&project={{ $project.Project }}" title="Project '{{ $project.Project }}' ({{ $project.Count }} heartbeats)">
+                <a href="summary?project={{ $project.Project }}" title="Project '{{ $project.Project }}' ({{ $project.Count }} heartbeats)">
                     <span class="text-lg font-semibold truncate">{{ $project.Project }}
                         {{ if $.LangIcon $project.TopLanguage }}
                         <span class="align-middle leading-none"><span class="iconify inline text-foreground text-lg ml-1" data-icon="{{ $.LangIcon $project.TopLanguage | urlSafe }}"></span></span>


### PR DESCRIPTION
Opening a project's stats from the Projects page hardcoded `interval=any`,
ignoring the period the user had last selected. This drops the hardcoded
interval so the project view reuses the persisted summary interval
(`wakapi_summary_interval` cookie), or `today` by default — same as the
summary page. The interval-cookie redirect now also keeps the `project`
query param (and returns), so the filter isn't lost for users who have a
cookie set.

Closes #948 
